### PR TITLE
feat: migrate WebUI to Plugin Pages and scope daily rankings by group

### DIFF
--- a/.astrbot-plugin/i18n/en-US.json
+++ b/.astrbot-plugin/i18n/en-US.json
@@ -1,0 +1,8 @@
+{
+  "pages": {
+    "steam-monitor": {
+      "title": "Steam Status Monitor",
+      "description": "View statistics, manage groups and bindings, and configure daily rankings"
+    }
+  }
+}

--- a/.astrbot-plugin/i18n/zh-CN.json
+++ b/.astrbot-plugin/i18n/zh-CN.json
@@ -1,0 +1,8 @@
+{
+  "pages": {
+    "steam-monitor": {
+      "title": "Steam 状态监控",
+      "description": "查看统计、管理群聊与绑定，并配置每日排行榜推送"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 - **字体自动管理**：自动检测并加载插件 `fonts` 目录下的 NotoSansHans 系列字体，渲染更稳定
 - **性能优化**：节流写盘、单点异常隔离、批量预拉取，避免拖慢 AstrBot 主进程与 WebUI
 - **原生逐指令权限**：每条指令使用 AstrBot 框架的 `admin/member` 权限，不再维护插件内部权限等级
-- **权限配置同步**：插件 WebUI 的“指令权限”页面直接读写 AstrBot 框架配置，并同步当前运行时权限
+- **AstrBot 内置管理页**：仪表盘、群聊、绑定、每日推送和权限管理直接集成在 AstrBot WebUI，无需额外端口
+- **权限配置同步**：内置管理页的“指令权限”直接读写 AstrBot 框架配置，并同步当前运行时权限
 
 ## 默认轮询间隔说明（智能轮询模式）
 | 玩家最近在线时间      | 轮询间隔 |
@@ -44,6 +45,7 @@
    - `/steam addid 123456789`（8 位好友码）
 4. 启动轮询：
    `/steam on`  启动本群 Steam 状态监控，后续状态变更会自动推送。
+5. 如需使用管理页面，在 AstrBot WebUI 的插件详情中打开“Steam 状态监控”页面。
 
 ## 配置项说明
 | 配置项 | 说明 | 默认值 |
@@ -94,7 +96,7 @@
 - `.steamwho @用户` / `.在干嘛 @用户`  即时查询QQ绑定玩家的Steam状态
 - `/steam rank [天数]` 查看本群游戏时长排行榜（默认今日，可指定天数）
 - `/steam allrank [天数]` 查看所有群游戏时长排行榜（默认今日，可指定天数）
-- `/steam rank_on [all|list|test|del]` 管理每日排行榜推送（all=全局排行，list=查看状态，test=即刻推送，del [群号]=删除指定群推送）
+- `/steam rank_on [all|list|test|del]` 管理每日排行榜推送（默认每群独立排行；all=显式使用共享全局排行，list=查看状态，test=即刻推送，del [群号]=删除指定群推送）
 - `/steam rs` 清除所有状态并初始化
 - `/steam achievement_on` 开启本群Steam成就推送
 - `/steam achievement_off` 关闭本群Steam成就推送
@@ -107,7 +109,7 @@
 - Python 3.7+
 - httpx
 - Pillow
-- AstrBot 框架
+- AstrBot >= 4.24.2
 
 ### 依赖安装方法
 如果显示缺少依赖，你可以尝试下载以下工具来进行修复
@@ -120,6 +122,11 @@ pip install httpx pillow
 > 如果本项目对您的生活 / 工作产生了帮助，或者您关注本项目的未来发展，请给项目 Star，这是我维护这个开源项目的动力 ❤️。
 
 ## 更新记录
+- 未发布
+  - **内置 WebUI**：外置 aiohttp 管理站迁移为 AstrBot Plugin Pages，复用 Dashboard 登录鉴权，不再监听独立端口
+  - **分群每日榜单**：默认按每个目标群的监控成员分别聚合、渲染和推送，单群无记录或失败不影响其他群
+  - **推送范围语义**：管理页明确区分“接收群聊”和“榜单内容范围”，全局榜单仅在显式选择时启用
+
 - V3.2.3（2026/07/23）
   - **权限系统迁移 (by LitChi-bit)**：回退 AstrBot 原生逐指令 `admin/member` 权限，移除插件内部 `permission_level`
   - **WebUI 权限管理 (by LitChi-bit)**：新增"指令权限"逐条配置，直接同步 AstrBot 框架持久化配置与运行时权限

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -123,11 +123,5 @@
     "type": "int",
     "hint": "每日自动推送排行榜的分钟数，默认30（即8:30推送）",
     "default": 30
-  },
-  "web_port": {
-    "description": "管理后台端口 -修改后重启AstrBot生效",
-    "type": "int",
-    "hint": "插件管理后台 HTTP 端口，默认 6195",
-    "default": 6195
   }
 }

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from .achievement_monitor import AchievementMonitor
 from .game_start_render import render_game_start  # 新增导入
 from .game_end_render import render_game_end  # 新增导入
 from .rank_render import render_rank_image  # 排行榜渲染
+from .rank_push import build_rank_push_scopes
 from PIL import Image as PILImage
 import io
 from datetime import datetime, timedelta
@@ -24,7 +25,7 @@ import tempfile
 import traceback
 import shutil
 from .superpower_util import load_abilities, get_daily_superpower  # 新增导入
-from .web import WebAdminServer  # Web 管理后台
+from .web_api import WebAdminAPI  # AstrBot 内置 WebUI
 
 @register(
     "steam_status_monitor_V3",
@@ -411,6 +412,7 @@ class SteamStatusMonitorV3(Star):
             logger.warning(f"保存 rank_push_groups.json 失败: {e}")
 
     def __init__(self, context: Context, config=None):
+        super().__init__(context)
         # 插件运行状态标志，重启后自动丢失
         if hasattr(self, '_ssm_running') and self._ssm_running:
             logger.error("当前插件已在运行中。请重启astrbot而非重载插件")
@@ -549,10 +551,10 @@ class SteamStatusMonitorV3(Star):
         self._load_bind_data()
         # --- 通知合并缓冲区：_delayed_quit_check 到期后将通知写入此队列，由主轮询统一 flush ---
         self._pending_end_notifications = {}  # {group_id: [notification_dict, ...]}
-        # --- Web 管理后台 ---
-        self._web_port = self.config.get('web_port', 6195)
-        self._web_server = WebAdminServer(self, self._web_port)
-        self._web_task = asyncio.create_task(self._web_server.start())
+        # --- AstrBot Plugin Pages 管理后台 ---
+        self.web_api = WebAdminAPI(self)
+        self.web_api.register_routes(context)
+        logger.info("[WebAdmin] 管理页面已注册到 AstrBot 内置 WebUI")
 
     async def init_poll_time_once(self):
         '''插件启动后10秒内进行一次全员初始化轮询，设置每个SteamID的next_poll_time，并输出一次初始日志'''
@@ -662,11 +664,6 @@ class SteamStatusMonitorV3(Star):
 
     async def terminate(self):
         '''插件被卸载/停用时取消所有后台任务并保存持久化数据'''
-        # 停止 Web 管理后台
-        if hasattr(self, '_web_server'):
-            await self._web_server.stop()
-        if hasattr(self, '_web_task') and not self._web_task.done():
-            self._web_task.cancel()
         # 取消主轮询循环和初始化任务，防止重载/禁用后残留多实例并发
         for t in (getattr(self, '_poll_loop_task', None), getattr(self, '_init_poll_task', None)):
             if t and not t.done():
@@ -1412,78 +1409,166 @@ class SteamStatusMonitorV3(Star):
         self._save_persistent_data(force=True)  # 清空后保存
         yield event.plain_result("Steam状态监控插件已重置，所有状态已清空。")
 
+    async def _render_daily_rank_file(self, rank_data):
+        """补齐排行榜展示信息并渲染为临时图片。"""
+        sid_set = {player["sid"] for player in rank_data}
+        sid_info = {}
+        if sid_set:
+            status_map = await self.fetch_player_statuses_batch(list(sid_set))
+            for sid, info in status_map.items():
+                sid_info[sid] = {
+                    "name": info.get("name") or sid,
+                    "avatar_url": info.get("avatarfull") or info.get("avatar"),
+                }
+
+        yesterday = self._get_day_key(-1)
+        day_data = self.play_records.get(yesterday, {})
+        for player in rank_data:
+            sid = player["sid"]
+            info = sid_info.get(sid, {})
+            player["name"] = self._resolve_bind_name(
+                sid,
+                info.get("name", sid[-8:]),
+            )
+            player["avatar_url"] = info.get("avatar_url")
+            player["top_game_id"] = None
+            if not player["games"]:
+                continue
+            top_name = player["games"][0]["name"]
+            for game_id, game_info in day_data.get(sid, {}).items():
+                if game_info.get("name") == top_name:
+                    player["top_game_id"] = game_id
+                    break
+
+        async def cover_fetcher(gameid):
+            return await self.get_game_cover_url(gameid)
+
+        avatar_frame_paths = {}
+        from .game_start_render import get_avatar_frame_path, get_avatar_frame_url
+
+        for player in rank_data:
+            sid = player.get("sid", "")
+            if not sid:
+                continue
+            frame_path = get_avatar_frame_path(
+                self.data_dir,
+                sid,
+                proxy=self.proxy,
+            )
+            if not frame_path:
+                frame_url = await get_avatar_frame_url(sid, proxy=self.proxy)
+                if frame_url:
+                    frame_path = get_avatar_frame_path(
+                        self.data_dir,
+                        sid,
+                        frame_url,
+                        proxy=self.proxy,
+                    )
+            if frame_path:
+                avatar_frame_paths[sid] = frame_path
+
+        font_path = self.get_font_path("NotoSansHans-Regular.otf")
+        img_bytes = await render_rank_image(
+            self.data_dir,
+            rank_data,
+            "昨日",
+            font_path=font_path,
+            proxy=self.proxy,
+            cover_fetcher=cover_fetcher,
+            avatar_frame_paths=avatar_frame_paths,
+        )
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
+            tmp.write(img_bytes)
+            return tmp.name
+
     async def _daily_rank_push(self, test_mode=False):
-        """每日自动推送昨日（4:00~4:00）排行榜到已开启的群。test_mode=True 时立即触发不检查日期去重"""
+        """推送昨日榜单；默认按目标群独立聚合，显式全局模式才共享总榜。"""
+        use_global_rank = getattr(self, "rank_push_all", False)
+        scopes = build_rank_push_scopes(
+            getattr(self, "rank_push_groups", []),
+            use_global_rank=use_global_rank,
+        )
+        if not scopes:
+            logger.warning(
+                "[排行榜] 没有目标群可推送"
+                "（请先使用 /steam rank_on 或 /steam rank_on all 开启推送）"
+            )
+            return
+
+        rendered_files = {}
         try:
-            is_all = getattr(self, 'rank_push_all', False)
-            # 推送目标严格来自 rank_push_groups（只有显式开启 rank_on 的群才推送）
-            target_groups = list(self.rank_push_groups)
-            if not target_groups:
-                logger.warning("[排行榜] 没有目标群可推送（请先使用 /steam rank_on 或 /steam rank_on all 开启推送）")
-                return
-            # 获取排行榜数据：rank_push_all 时使用全局排行 (group_id=None)
-            rank_data = self._get_rank_data(days=1, group_id=None if is_all else None, base_day_offset=-1)
-            if not rank_data:
-                logger.info("[排行榜] 昨日无游玩记录，跳过推送")
-                return
-            # 补充玩家信息（只渲染一次，所有群共用同一张图）
-            sid_set = {p["sid"] for p in rank_data}
-            sid_info = {}
-            if sid_set:
-                status_map = await self.fetch_player_statuses_batch(list(sid_set))
-                for sid, info in status_map.items():
-                    sid_info[sid] = {"name": info.get("name") or sid, "avatar_url": info.get("avatarfull") or info.get("avatar")}
-            for p in rank_data:
-                info = sid_info.get(p["sid"], {})
-                p["name"] = self._resolve_bind_name(p["sid"], info.get("name", p["sid"][-8:]))
-                p["avatar_url"] = info.get("avatar_url")
-                p["top_game_id"] = None
-            # 反查封面gameid
-            yesterday = self._get_day_key(-1)
-            for p in rank_data:
-                if not p["games"]: continue
-                top_name = p["games"][0]["name"]
-                day_data = self.play_records.get(yesterday, {})
-                sid_games = day_data.get(p["sid"], {})
-                for gid, ginfo in sid_games.items():
-                    if ginfo.get("name") == top_name:
-                        p["top_game_id"] = gid
-                        break
-            async def cover_fetcher(gameid):
-                return await self.get_game_cover_url(gameid)
-            # 获取头像框路径
-            avatar_frame_paths = {}
-            from .game_start_render import get_avatar_frame_url, get_avatar_frame_path
-            for p in rank_data:
-                sid = p.get("sid", "")
-                if sid:
-                    fp = get_avatar_frame_path(self.data_dir, sid, proxy=self.proxy)
-                    if not fp:
-                        frame_url = await get_avatar_frame_url(sid, proxy=self.proxy)
-                        if frame_url: fp = get_avatar_frame_path(self.data_dir, sid, frame_url, proxy=self.proxy)
-                    if fp: avatar_frame_paths[sid] = fp
-            font_path = self.get_font_path('NotoSansHans-Regular.otf')
-            img_bytes = await render_rank_image(self.data_dir, rank_data, "昨日", font_path=font_path, proxy=self.proxy, cover_fetcher=cover_fetcher, avatar_frame_paths=avatar_frame_paths)
-            import tempfile
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
-                tmp.write(img_bytes)
-                tmp_path = tmp.name
-            # 推送到所有目标群
-            for group_id in target_groups:
-                try:
-                    session = getattr(self, 'notify_sessions', {}).get(group_id, None)
-                    if session:
-                        await self.context.send_message(session, MessageChain([
-                            Plain("📊 昨日游戏时长排行榜来啦！\n"),
-                            Image.fromFileSystem(tmp_path)
-                        ]))
-                        logger.info(f"[排行榜] 已推送昨日排行榜到群 {group_id}")
+            for target_group_id, data_group_id in scopes:
+                render_key = (
+                    ("global", None)
+                    if data_group_id is None
+                    else ("group", data_group_id)
+                )
+                if render_key not in rendered_files:
+                    rank_data = self._get_rank_data(
+                        days=1,
+                        group_id=data_group_id,
+                        base_day_offset=-1,
+                    )
+                    if not rank_data:
+                        scope_label = (
+                            "全部群"
+                            if data_group_id is None
+                            else f"群 {data_group_id}"
+                        )
+                        logger.info(
+                            f"[排行榜] {scope_label}昨日无游玩记录，跳过推送"
+                        )
+                        rendered_files[render_key] = None
                     else:
-                        logger.warning(f"[排行榜] 群 {group_id} 未找到推送会话，跳过")
+                        try:
+                            rendered_files[render_key] = (
+                                await self._render_daily_rank_file(rank_data)
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"[排行榜] 渲染群 {data_group_id or '全局'} "
+                                f"昨日榜单失败: {e}"
+                            )
+                            rendered_files[render_key] = None
+
+                tmp_path = rendered_files[render_key]
+                if not tmp_path:
+                    continue
+                try:
+                    session = getattr(self, "notify_sessions", {}).get(
+                        target_group_id
+                    )
+                    if not session:
+                        logger.warning(
+                            f"[排行榜] 群 {target_group_id} 未找到推送会话，跳过"
+                        )
+                        continue
+                    await self.context.send_message(
+                        session,
+                        MessageChain([
+                            Plain("📊 昨日游戏时长排行榜来啦！\n"),
+                            Image.fromFileSystem(tmp_path),
+                        ]),
+                    )
+                    logger.info(
+                        f"[排行榜] 已推送昨日排行榜到群 {target_group_id}"
+                    )
                 except Exception as e:
-                    logger.error(f"[排行榜] 推送群 {group_id} 失败: {e}")
+                    logger.error(
+                        f"[排行榜] 推送群 {target_group_id} 失败: {e}"
+                    )
         except Exception as e:
             logger.error(f"[排行榜] 每日推送异常: {e}")
+        finally:
+            for tmp_path in {
+                path for path in rendered_files.values() if path
+            }:
+                try:
+                    os.unlink(tmp_path)
+                except OSError as e:
+                    logger.warning(
+                        f"[排行榜] 清理临时图片失败 {tmp_path}: {e}"
+                    )
     async def _render_and_send_rank(self, event, group_id, days, period_label, is_all=False):
         """生成排行榜图片并发送"""
         try:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,8 +1,10 @@
 name: steam_status_monitor_V3
+display_name: Steam 状态监控
 desc: 用于监控steam指定玩家的在线/离线/游戏状态变更，并在状态变化时推送通知。
 author: Maoer
 repo: https://github.com/Maoer233/astrbot_plugin_steam_status_monitor
 version: 3.2.3
+astrbot_version: ">=4.24.2"
 tags:
   - steam
 social_link: https://github.com/Maoer233

--- a/pages/steam-monitor/app.js
+++ b/pages/steam-monitor/app.js
@@ -1,13 +1,27 @@
 // Steam Monitor Admin
+const bridge = window.AstrBotPluginPage;
+
+function parsePluginEndpoint(url) {
+  const [rawPath, rawQuery = ""] = String(url).split("?", 2);
+  const endpoint = rawPath
+    .replace(/^\/?api\/?/, "")
+    .replace(/^\/+|\/+$/g, "");
+  const params = {};
+  for (const [key, value] of new URLSearchParams(rawQuery)) {
+    params[key] = value;
+  }
+  return {endpoint, params};
+}
+
 const API = {
-  async request(u,options){
-    const r=await fetch(u,options);const text=await r.text();let data={};
-    if(text){try{data=JSON.parse(text)}catch(_){data={error:text}}}
-    if(!r.ok)throw new Error(data.error||data.message||`HTTP ${r.status}`);
-    return data
+  async get(url) {
+    const {endpoint, params} = parsePluginEndpoint(url);
+    return bridge.apiGet(endpoint, Object.keys(params).length ? params : undefined);
   },
-  async get(u){return this.request(u)},
-  async post(u,d){return this.request(u,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(d)})}
+  async post(url, data) {
+    const {endpoint} = parsePluginEndpoint(url);
+    return bridge.apiPost(endpoint, data || {});
+  },
 };
 document.querySelectorAll(".nav-item").forEach(it=>{it.addEventListener("click",()=>{const p=it.dataset.page;if(p)navigateTo(p)})});
 
@@ -16,13 +30,53 @@ async function navigateTo(page,params){const t=document.getElementById("hplayer-
   const c=document.getElementById("content");
   c.innerHTML='<div class="page-loading"><span class="mdi mdi-loading mdi-spin"></span><p>加载中...</p></div>';
   try{const pages={dashboard:renderDashboard,gantt:renderGantt,heatmap:()=>renderHeatmap(params),groups:renderGroups,bindings:renderBindings,push:renderPush,settings:renderSettings,test:renderTest};await(pages[page]||renderDashboard)()}
-  catch(e){c.innerHTML=`<div class="empty-state"><span class="mdi mdi-alert-circle"></span><p>加载失败: ${e.message}</p><button class="btn btn-primary mt-8" onclick="navigateTo('${page}')">重试</button></div>`}
+  catch(e){c.innerHTML=`<div class="empty-state"><span class="mdi mdi-alert-circle"></span><p>加载失败: ${escapeHtml(e.message)}</p><button class="btn btn-primary mt-8" onclick="navigateTo(${jsArg(page)})">重试</button></div>`}
 }
 
 function toast(msg,t){const e=document.createElement("div");e.className=`toast toast-${t||"success"}`;e.textContent=msg;document.body.appendChild(e);setTimeout(()=>e.remove(),3000)}
+let pageDialogResolve=null;
+let pageDialogMode="confirm";
+function showPageDialog({title,label="",mode="confirm",value=""}){
+  const overlay=document.getElementById("page-dialog");
+  const inputWrap=document.getElementById("page-dialog-input-wrap");
+  const input=document.getElementById("page-dialog-input");
+  document.getElementById("page-dialog-title").textContent=title;
+  document.getElementById("page-dialog-label").textContent=label;
+  inputWrap.style.display=mode==="prompt"?"block":"none";
+  input.value=value;
+  pageDialogMode=mode;
+  overlay.classList.add("show");
+  if(mode==="prompt")setTimeout(()=>input.focus(),0);
+  return new Promise(resolve=>{pageDialogResolve=resolve})
+}
+function pagePrompt(title,label){return showPageDialog({title,label,mode:"prompt"})}
+function pageConfirm(title){return showPageDialog({title,mode:"confirm"})}
+window.resolvePageDialog=confirmed=>{
+  const overlay=document.getElementById("page-dialog");
+  const input=document.getElementById("page-dialog-input");
+  overlay.classList.remove("show");
+  if(!pageDialogResolve)return;
+  const resolve=pageDialogResolve;
+  pageDialogResolve=null;
+  resolve(confirmed?(pageDialogMode==="prompt"?input.value.trim():true):(pageDialogMode==="prompt"?null:false))
+};
 function steamTheme(){return{backgroundColor:"transparent",textStyle:{color:"#e1e8ed"},legend:{textStyle:{color:"#aeb9c2"}},tooltip:{backgroundColor:"#2a475e",borderColor:"#355066",textStyle:{color:"#e1e8ed"}}}}
 function disposeChart(id){const el=document.getElementById(id);if(el){const inst=echarts.getInstanceByDom(el);if(inst)inst.dispose()}}
 function initChart(id){disposeChart(id);const el=document.getElementById(id);return el?echarts.init(el):null}
+const coverCache=new Map();
+async function loadCover(gameid){
+  if(!gameid)return"";
+  if(coverCache.has(gameid))return coverCache.get(gameid);
+  try{
+    const data=await API.get(`/api/games/cover/${gameid}`);
+    const url=data.data_url||"";
+    coverCache.set(gameid,url);
+    return url
+  }catch(_){
+    coverCache.set(gameid,"");
+    return""
+  }
+}
 
 // ====== Dashboard ======
 let dashPeriod="week";
@@ -57,30 +111,44 @@ function renderDashPlayerCards(players){
   container.innerHTML=players.map(p=>{
     const playing=!!p.gameid;const online=p.personastate>0;
     const border=playing?"var(--accent-green)":online?"var(--accent)":"var(--border-color)";
-    const stxt=playing?`🎮 ${p.game||"游戏中"}`:online?"● 在线":"○ 离线";
+    const stxt=playing?`🎮 ${escapeHtml(p.game||"游戏中")}`:online?"● 在线":"○ 离线";
     const sc=playing?"var(--accent-green)":online?"var(--accent)":"var(--text-muted)";
-    return `<div class="dash-pcard" data-sid="${p.sid}" style="border-color:${border}" onclick="navigateTo('heatmap',{player:'${p.sid}'})">
+    return `<div class="dash-pcard" data-sid="${escapeAttr(p.sid)}" style="border-color:${border}" onclick="navigateTo('heatmap',{player:${jsArg(p.sid)}})">
       <div class="dash-pav"><span class="mdi mdi-loading mdi-spin"></span></div>
-      <div><div style="font-size:13px;font-weight:500;color:var(--text-bright)">${p.name}</div><div style="font-size:11px;color:${sc}">${stxt}</div></div></div>`
+      <div><div style="font-size:13px;font-weight:500;color:var(--text-bright)">${escapeHtml(p.name)}</div><div style="font-size:11px;color:${sc}">${stxt}</div></div></div>`
   }).join("");
-  Promise.all(players.map(p=>loadAvatar(p.sid).then(av=>{const c=document.querySelector(`.dash-pcard[data-sid="${p.sid}"]`);if(!c)return;const a=c.querySelector(".dash-pav");if(a&&av)a.innerHTML=`<img src="${av}">`})));
+  Promise.all(players.map(p=>loadAvatar(p.sid).then(av=>{const c=document.querySelector(`.dash-pcard[data-sid="${CSS.escape(String(p.sid))}"]`);if(!c)return;const a=c.querySelector(".dash-pav");if(a&&av)a.innerHTML=`<img src="${safeImageUrl(av)}">`})));
 }
 
 async function loadDashboardCharts(){
   const pm={today:{d:1,o:0},yesterday:{d:1,o:-1},week:{d:7,o:0},month:{d:30,o:0}};
   const {d:days,o:offset}=pm[dashPeriod]||pm.week;
-  const img=document.getElementById("rank-image");if(img)img.src=`/api/dashboard/rank-image?days=${days}&offset=${offset}&t=${Date.now()}`;
+  const img=document.getElementById("rank-image");
+  if(img){
+    try{
+      const rank=await API.get(`/api/dashboard/rank-image?days=${days}&offset=${offset}`);
+      const rankUrl=safeImageUrl(rank.data_url);
+      img.src=rankUrl;
+      img.style.display=rankUrl?"block":"none"
+    }catch(_){
+      img.removeAttribute("src");
+      img.style.display="none"
+    }
+  }
   const gd=await API.get(`/api/gantt/data?days=${days}&offset=${offset}`);
   const players=gd.players||[];const details=gd.game_details||{};const gameColors=gd.game_colors||{};
   const gm={};
   players.forEach(p=>(p.sessions||[]).forEach(s=>{gm[s.gameid]=gm[s.gameid]||{name:s.game_name,minutes:0,gameid:s.gameid};gm[s.gameid].minutes+=s.duration_min||0}));
   const tg=Object.values(gm).sort((a,b)=>b.minutes-a.minutes);const top9=tg.slice(0,9);const restMins=tg.slice(9).reduce((s,g)=>s+g.minutes,0);if(restMins>0)top9.push({name:"其他",minutes:restMins,gameid:""});
+  const covers={};
+  await Promise.all(top9.filter(g=>g.gameid).map(async g=>{covers[g.gameid]=await loadCover(g.gameid)}));
   const gc=initChart("chart-top-games");if(!gc)return;
   const cols=["#5aa9d6","#b2d430","#e8a030","#b37cd4","#e05050","#50c8c8","#ff8c60","#60b0e0","#e0a0c0","#80d080"];
   gc.setOption({...steamTheme(),tooltip:{trigger:"item",backgroundColor:"#1e2c38",borderColor:"#2e4254",borderWidth:1,extraCssText:"border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.5)",formatter:p=>{
-    const det=details[p.data.gameid];if(!det||!det.players)return`<b>${p.name}</b><br/>${p.value}分钟`;
-    let h=`<div style="min-width:200px;max-width:260px"><b style="font-size:14px">${det.name}</b><img src="/api/games/cover/${p.data.gameid}" style="width:100%;max-width:240px;border-radius:6px;margin:8px 0;display:block" onerror="this.style.display='none'">`;
-    det.players.slice(0,5).forEach(pl=>{h+=`<div style="display:flex;justify-content:space-between;font-size:12px;margin:3px 0"><span>${pl.name}</span><span style="color:var(--accent)">${(pl.minutes/60).toFixed(1)}h</span></div>`});
+    const det=details[p.data.gameid];if(!det||!det.players)return`<b>${escapeHtml(p.name)}</b><br/>${p.value}分钟`;
+    const cover=covers[p.data.gameid]||"";
+    let h=`<div style="min-width:200px;max-width:260px"><b style="font-size:14px">${escapeHtml(det.name)}</b>${cover?`<img src="${safeImageUrl(cover)}" style="width:100%;max-width:240px;border-radius:6px;margin:8px 0;display:block">`:""}`;
+    det.players.slice(0,5).forEach(pl=>{h+=`<div style="display:flex;justify-content:space-between;font-size:12px;margin:3px 0"><span>${escapeHtml(pl.name)}</span><span style="color:var(--accent)">${(pl.minutes/60).toFixed(1)}h</span></div>`});
     if(det.players.length>5){const om=det.players.slice(5).reduce((s,pl)=>s+pl.minutes,0);h+=`<div style="display:flex;justify-content:space-between;font-size:11px;color:var(--text-muted)"><span>其他${det.players.length-5}位</span><span>${(om/60).toFixed(1)}h</span></div>`}
     h+="</div>";return h}},legend:{bottom:0,textStyle:{color:"#aeb9c2"}},series:[{type:"pie",radius:["35%","60%"],center:["50%","32%"],data:top9.map((g,i)=>({name:g.name,value:g.minutes,gameid:g.gameid,itemStyle:{color:g.name==="其他"?"#555":cols[i%cols.length]}})),label:{color:"#e1e8ed",formatter:"{d}%",fontSize:12},emphasis:{label:{fontSize:16,fontWeight:"bold"}}}]});
 }
@@ -105,14 +173,14 @@ async function loadGantt(days,offset){
   const players=data.players||[];
   const gs={};players.forEach(p=>(p.sessions||[]).forEach(s=>{gs[s.gameid]=s.game_name}));
   const leg=document.getElementById("gantt-legend");
-  leg.innerHTML=Object.keys(gs).map(gid=>`<span style="display:inline-flex;align-items:center;gap:4px;font-size:12px;color:var(--text-secondary)"><span style="width:12px;height:12px;border-radius:2px;background:${gch(gid)};display:inline-block"></span>${gs[gid]}</span>`).join("");
+  leg.innerHTML=Object.keys(gs).map(gid=>`<span style="display:inline-flex;align-items:center;gap:4px;font-size:12px;color:var(--text-secondary)"><span style="width:12px;height:12px;border-radius:2px;background:${gch(gid)};display:inline-block"></span>${escapeHtml(gs[gid])}</span>`).join("");
   const chart=initChart("gantt-chart");if(!chart)return;
   if(!players.length){chart.clear();leg.innerHTML='<span style="color:var(--text-muted)">暂无记录</span>';return}
   const names=players.map(p=>p.name);const sd=[];
   players.forEach((p,pi)=>(p.sessions||[]).forEach(s=>{if(s.start>0&&s.end>0)sd.push({name:p.name,value:[pi,new Date(s.start*1000),new Date(s.end*1000)],game_name:s.game_name,duration_min:s.duration_min,gameid:s.gameid,itemStyle:{color:gch(s.gameid)}})}));
   if(!sd.length){chart.clear();return}
   const mT=data.time_range?new Date(data.time_range.start):new Date();const xT=data.time_range?new Date(data.time_range.end):new Date();
-  chart.setOption({...steamTheme(),tooltip:{formatter:p=>{const sd=new Date(p.data.value[1]).toTimeString().slice(0,5);const ed=new Date(p.data.value[2]).toTimeString().slice(0,5);return`<b>${p.name}</b> - ${p.data.game_name}<br/>${sd} → ${ed}<br/>时长: ${p.data.duration_min}分钟`}},grid:{left:140,right:30,top:20,bottom:50},
+  chart.setOption({...steamTheme(),tooltip:{formatter:p=>{const sd=new Date(p.data.value[1]).toTimeString().slice(0,5);const ed=new Date(p.data.value[2]).toTimeString().slice(0,5);return`<b>${escapeHtml(p.name)}</b> - ${escapeHtml(p.data.game_name)}<br/>${sd} → ${ed}<br/>时长: ${p.data.duration_min}分钟`}},grid:{left:140,right:30,top:20,bottom:50},
     xAxis:{type:"time",min:mT,max:xT,axisLabel:{color:"#aeb9c2",formatter:v=>{const d=new Date(v);return`${String(d.getHours()).padStart(2,"0")}:${String(d.getMinutes()).padStart(2,"0")}`}},splitLine:{show:true,lineStyle:{color:"rgba(255,255,255,0.06)",type:"dashed"}}},
     yAxis:{type:"category",data:names,axisLabel:{color:"#e1e8ed",width:120,overflow:"truncate"}},
     series:[{type:"custom",renderItem:(p,api)=>{const ci=api.value(0);const s=api.coord([api.value(1),ci]);const e=api.coord([api.value(2),ci]);return{type:"rect",shape:{x:s[0],y:s[1]-11,width:Math.max(e[0]-s[0],4),height:22},style:{fill:api.style().fill,opacity:0.85}}},encode:{x:[1,2],y:0},data:sd}],
@@ -144,10 +212,10 @@ async function renderHeatmap(params){
   }
   const pd=document.getElementById("heatmap-players");
   if(!data.players||!data.players.length){pd.innerHTML='<div class="empty-state"><span class="mdi mdi-calendar-blank"></span><p>暂无记录</p></div>';return}
-  pd.innerHTML=data.players.map(p=>`<div class="player-card-mini" data-sid="${p.sid}" onclick="navigateTo('heatmap',{player:'${p.sid}'})">
+  pd.innerHTML=data.players.map(p=>`<div class="player-card-mini" data-sid="${escapeAttr(p.sid)}" onclick="navigateTo('heatmap',{player:${jsArg(p.sid)}})">
     <div class="player-avatar"><span class="mdi mdi-loading mdi-spin" style="font-size:16px;color:var(--text-muted)"></span></div>
-    <div><div style="font-size:14px;font-weight:500;color:var(--text-bright)">${p.name}</div><div style="font-size:12px;color:var(--text-secondary)">${(p.total_minutes/60).toFixed(1)}h</div></div></div>`).join("");
-  Promise.all(data.players.map(p=>loadAvatar(p.sid).then(av=>{const card=document.querySelector(`.player-card-mini[data-sid="${p.sid}"]`);if(!card)return;const a=card.querySelector(".player-avatar");if(a&&av)a.innerHTML=`<img src="${av}">`})));
+    <div><div style="font-size:14px;font-weight:500;color:var(--text-bright)">${escapeHtml(p.name)}</div><div style="font-size:12px;color:var(--text-secondary)">${(p.total_minutes/60).toFixed(1)}h</div></div></div>`).join("");
+  Promise.all(data.players.map(p=>loadAvatar(p.sid).then(av=>{const card=document.querySelector(`.player-card-mini[data-sid="${CSS.escape(String(p.sid))}"]`);if(!card)return;const a=card.querySelector(".player-avatar");if(a&&av)a.innerHTML=`<img src="${safeImageUrl(av)}">`})));
   document.querySelectorAll(".player-card-mini").forEach(card=>{const sid=card.dataset.sid;
     card.addEventListener("mouseenter",async e=>await showTooltip(e,sid));
     card.addEventListener("mouseleave",()=>{const t=document.getElementById("hplayer-tooltip");if(t)t.style.display="none"});
@@ -157,20 +225,57 @@ async function loadAvatar(sid){try{const r=await API.get(`/api/players/avatar/${
 async function showTooltip(e,sid){
   const t=document.getElementById("hplayer-tooltip");try{
     const info=await API.get(`/api/players/info/${sid}`);const av=await loadAvatar(sid);
-    t.innerHTML=`<div style="display:flex;gap:12px;align-items:flex-start"><img src="${av}" style="width:48px;height:48px;border-radius:8px;background:var(--bg-tertiary)" onerror="this.style.display='none'"><div><div style="font-size:15px;font-weight:500;color:var(--text-bright)">${info.name}</div><div style="font-size:11px;color:var(--text-muted)">SteamID:${info.steamid}</div>${info.current_game?`<div style="font-size:12px;color:var(--accent-green);margin-top:2px">🎮 ${info.current_game}</div>`:""}<div style="font-size:12px;color:var(--text-secondary);margin-top:6px">总计${(info.total_minutes/60).toFixed(1)}h·${info.total_sessions}次</div></div></div>`;
+    t.innerHTML=`<div style="display:flex;gap:12px;align-items:flex-start"><img src="${safeImageUrl(av)}" style="width:48px;height:48px;border-radius:8px;background:var(--bg-tertiary)" onerror="this.style.display='none'"><div><div style="font-size:15px;font-weight:500;color:var(--text-bright)">${escapeHtml(info.name)}</div><div style="font-size:11px;color:var(--text-muted)">SteamID:${escapeHtml(info.steamid)}</div>${info.current_game?`<div style="font-size:12px;color:var(--accent-green);margin-top:2px">🎮 ${escapeHtml(info.current_game)}</div>`:""}<div style="font-size:12px;color:var(--text-secondary);margin-top:6px">总计${(info.total_minutes/60).toFixed(1)}h·${info.total_sessions}次</div></div></div>`;
     t.style.display="block";t.style.left=(e.clientX+16)+"px";t.style.top=(e.clientY+16)+"px"}catch(ex){t.style.display="none"}
 }
 async function renderPlayerHeatmap(sid){
   const data=await API.get(`/api/heatmap/player/${sid}?period=90`);const av=await loadAvatar(sid);
   const c=document.getElementById("content");
-  c.innerHTML=`<div class="flex-between mb-20"><h2 class="page-title"><img src="${av}" style="width:28px;height:28px;border-radius:6px;vertical-align:middle;margin-right:8px;background:var(--bg-tertiary)" onerror="this.style.display='none'">${data.name}的贡献日历</h2><button class="btn btn-primary" onclick="navigateTo('heatmap')">←返回</button></div>
+  c.innerHTML=`<div class="flex-between mb-20"><h2 class="page-title"><img src="${safeImageUrl(av)}" style="width:28px;height:28px;border-radius:6px;vertical-align:middle;margin-right:8px;background:var(--bg-tertiary)" onerror="this.style.display='none'">${escapeHtml(data.name)}的贡献日历</h2><button class="btn btn-primary" onclick="navigateTo('heatmap')">←返回</button></div>
     <div class="stats-grid mb-20"><div class="stat-card"><div class="stat-value">${(data.total_minutes/60).toFixed(1)}h</div><div class="stat-label">总时长</div></div><div class="stat-card"><div class="stat-value">${data.avg_daily_minutes}min</div><div class="stat-label">日均</div></div><div class="stat-card"><div class="stat-value">${data.days_played}</div><div class="stat-label">活跃天数</div></div></div>
     <div class="charts-row"><div class="card"><div class="card-title">日历热力图</div><div id="heatmap-player-cal" class="chart-box"></div></div><div class="card"><div class="card-title">游戏占比</div><div id="heatmap-player-pie" class="chart-box-lg" style="height:480px"></div></div></div>`;
   if(typeof echarts!=="undefined"){
     const hd=data.heatmap_daily||{};const dates=Object.keys(hd).sort();const cd=dates.map(d=>[d,hd[d]]);const maxV=Math.max(...Object.values(hd),60);
     const hm=initChart("heatmap-player-cal");if(hm)hm.setOption({...steamTheme(),tooltip:{formatter:p=>{const hrs=(p.data[1]/60).toFixed(1);return`${p.data[0]}<br/><b>${p.data[1]}</b>分钟(${hrs}h)`}},visualMap:{min:0,max:maxV,orient:"horizontal",left:"center",bottom:0,inRange:{color:["rgb(17,22,28)","rgb(2,46,18)","#006d32","#26a641","#39d353","#6ae07a"]},textStyle:{color:"#aeb9c2"}},calendar:{range:dates.length?[dates[0],dates[dates.length-1]]:"2026-07",cellSize:[20,20],dayLabel:{color:"#aeb9c2"},monthLabel:{color:"#aeb9c2"},itemStyle:{borderColor:"#0a0e12",borderWidth:3,borderRadius:2}},series:[{type:"heatmap",coordinateSystem:"calendar",data:cd}]});
-    const cols=["#5aa9d6","#b2d430","#e8a030","#b37cd4","#e05050","#50c8c8","#ff8c60","#60b0e0"];const pc=initChart("heatmap-player-pie");
-    if(pc){const pg=(data.top_games||[]).sort((a,b)=>b.minutes-a.minutes);const pt9=pg.slice(0,9);const pr=pg.slice(9).reduce((s,g)=>s+g.minutes,0);if(pr>0)pt9.push({name:"其他",minutes:pr});pc.setOption({...steamTheme(),tooltip:{backgroundColor:"#1e2c38",borderColor:"#2e4254",borderWidth:1,extraCssText:"border-radius:8px",trigger:"item",formatter:p=>{const gi=p.data.gameid;return`<div style="min-width:160px"><b>${p.name}</b>${gi?`<br><img src="/api/games/cover/${gi}" style="width:100%;max-width:220px;border-radius:6px;margin:8px 0" onerror="this.style.display='none'">`:""}<br>${p.value}分钟</div>`}},legend:{bottom:0,textStyle:{color:"#aeb9c2"}},series:[{type:"pie",radius:["35%","60%"],center:["50%","32%"],data:pt9.map((g,i)=>({name:g.name,value:g.minutes,itemStyle:{color:g.name==="其他"?"#555":cols[i%cols.length]}})),label:{color:"#e1e8ed",formatter:"{d}%",fontSize:12},emphasis:{label:{fontSize:16,fontWeight:"bold"}}}]});}
+    const cols=["#5aa9d6","#b2d430","#e8a030","#b37cd4","#e05050","#50c8c8","#ff8c60","#60b0e0"];
+    const pc=initChart("heatmap-player-pie");
+    if(pc){
+      const pg=(data.top_games||[]).sort((a,b)=>b.minutes-a.minutes);
+      const pt9=pg.slice(0,9);
+      const pr=pg.slice(9).reduce((s,g)=>s+g.minutes,0);
+      if(pr>0)pt9.push({name:"其他",minutes:pr,gameid:""});
+      const covers={};
+      await Promise.all(pt9.filter(g=>g.gameid).map(async g=>{covers[g.gameid]=await loadCover(g.gameid)}));
+      pc.setOption({
+        ...steamTheme(),
+        tooltip:{
+          backgroundColor:"#1e2c38",
+          borderColor:"#2e4254",
+          borderWidth:1,
+          extraCssText:"border-radius:8px",
+          trigger:"item",
+          formatter:p=>{
+            const gi=p.data.gameid;
+            const cover=covers[gi]||"";
+            return`<div style="min-width:160px"><b>${escapeHtml(p.name)}</b>${cover?`<br><img src="${safeImageUrl(cover)}" style="width:100%;max-width:220px;border-radius:6px;margin:8px 0">`:""}<br>${p.value}分钟</div>`
+          },
+        },
+        legend:{bottom:0,textStyle:{color:"#aeb9c2"}},
+        series:[{
+          type:"pie",
+          radius:["35%","60%"],
+          center:["50%","32%"],
+          data:pt9.map((g,i)=>({
+            name:g.name,
+            value:g.minutes,
+            gameid:g.gameid,
+            itemStyle:{color:g.name==="其他"?"#555":cols[i%cols.length]},
+          })),
+          label:{color:"#e1e8ed",formatter:"{d}%",fontSize:12},
+          emphasis:{label:{fontSize:16,fontWeight:"bold"}},
+        }],
+      });
+    }
   }
 }
 
@@ -181,23 +286,23 @@ async function renderGroups(){
   c.innerHTML=`<div class="flex-between mb-20"><h2 class="page-title">群聊管理</h2><div class="flex gap-8"><span style="color:var(--text-muted)">${gids.length}个群</span><button class="btn btn-primary btn-sm" onclick="addGroup()">+添加群聊</button></div></div>
     <div class="groups-layout"><div class="card" id="group-list"></div><div class="card" id="group-detail"><div class="empty-state">选择一个群</div></div></div>`;
   let sel=gids[0]||null;
-  function renderList(){const l=document.getElementById("group-list");l.innerHTML=gids.map(gid=>`<div class="group-list-item${gid===sel?" active":""}" style="display:flex;justify-content:space-between;align-items:center" onclick="selG('${gid}')"><span>群${gid}(${groups[gid].length}人)</span><button class="btn btn-danger btn-sm" style="padding:2px 6px;font-size:11px" onclick="event.stopPropagation();delGroup('${gid}')">✕</button></div>`).join("")}
+  function renderList(){const l=document.getElementById("group-list");l.innerHTML=gids.map(gid=>`<div class="group-list-item${gid===sel?" active":""}" style="display:flex;justify-content:space-between;align-items:center" onclick="selG(${jsArg(gid)})"><span>群${escapeHtml(gid)}(${groups[gid].length}人)</span><button class="btn btn-danger btn-sm" style="padding:2px 6px;font-size:11px" onclick="event.stopPropagation();delGroup(${jsArg(gid)})">✕</button></div>`).join("")}
   window.selG=g=>{sel=g;renderList();renderDetail(g)};
   async function renderDetail(gid){
     const ps=groups[gid]||[];const d=document.getElementById("group-detail");
-    let h=`<div class="flex-between mb-16"><span class="card-title" style="margin-bottom:0">群${gid}</span><button class="btn btn-primary btn-sm" onclick="addSteamID('${gid}')">+添加SteamID</button></div>`;
+    let h=`<div class="flex-between mb-16"><span class="card-title" style="margin-bottom:0">群${escapeHtml(gid)}</span><button class="btn btn-primary btn-sm" onclick="addSteamID(${jsArg(gid)})">+添加SteamID</button></div>`;
     if(!ps.length){h+='<div class="empty-state"><span class="mdi mdi-account-off"></span><p>暂无玩家</p></div>';d.innerHTML=h;return}
     h+='<table class="table"><thead><tr><th></th><th>玩家</th><th>状态</th><th>操作</th></tr></thead><tbody>';
-    ps.forEach(p=>{const bg=p.gameid?'<span class="badge badge-playing">游戏中</span>':p.personastate>0?'<span class="badge badge-online">在线</span>':'<span class="badge badge-offline">离线</span>';h+=`<tr><td><div class="gav-${p.sid}" style="width:28px;height:28px;border-radius:6px;background:var(--bg-tertiary);display:flex;align-items:center;justify-content:center"><span class="mdi mdi-loading mdi-spin" style="font-size:14px;color:var(--text-muted)"></span></div></td><td>${p.name}</td><td>${bg}</td><td><button class="btn btn-danger btn-sm" onclick="removeSteamID('${gid}','${p.sid}','${p.name}')">删除</button></td></tr>`});
+    ps.forEach(p=>{const bg=p.gameid?'<span class="badge badge-playing">游戏中</span>':p.personastate>0?'<span class="badge badge-online">在线</span>':'<span class="badge badge-offline">离线</span>';h+=`<tr><td><div data-avatar-sid="${escapeAttr(p.sid)}" style="width:28px;height:28px;border-radius:6px;background:var(--bg-tertiary);display:flex;align-items:center;justify-content:center"><span class="mdi mdi-loading mdi-spin" style="font-size:14px;color:var(--text-muted)"></span></div></td><td>${escapeHtml(p.name)}</td><td>${bg}</td><td><button class="btn btn-danger btn-sm" onclick="removeSteamID(${jsArg(gid)},${jsArg(p.sid)},${jsArg(p.name)})">删除</button></td></tr>`});
     h+='</tbody></table>';d.innerHTML=h;
-    Promise.all(ps.map(p=>loadAvatar(p.sid).then(av=>{const el=document.querySelector(`.gav-${p.sid}`);if(el&&av)el.innerHTML=`<img src="${av}" style="width:28px;height:28px;border-radius:6px;background:var(--bg-tertiary)">`})));
+    Promise.all(ps.map(p=>loadAvatar(p.sid).then(av=>{const el=document.querySelector(`[data-avatar-sid="${CSS.escape(String(p.sid))}"]`);if(el&&av)el.innerHTML=`<img src="${safeImageUrl(av)}" style="width:28px;height:28px;border-radius:6px;background:var(--bg-tertiary)">`})));
   }
   renderList();if(sel)await renderDetail(sel);
 }
-window.addGroup=async()=>{const g=prompt("群号:");if(!g)return;const r=await API.post("/api/groups/add-group",{group_id:g});if(r.ok){toast("已添加");navigateTo("groups")}else toast(r.error||"失败","error")};
-window.delGroup=async gid=>{if(!confirm(`删除群${gid}？`))return;const r=await API.post("/api/groups/delete-group",{group_id:gid});if(r.ok){toast("已删除");navigateTo("groups")}else toast(r.error||"失败","error")};
-window.addSteamID=async gid=>{const s=prompt("SteamID:");if(!s)return;const r=await API.post("/api/groups/add",{group_id:gid,steamid:s});if(r.ok){toast("添加成功");navigateTo("groups")}else toast(r.error||"失败","error")};
-window.removeSteamID=async(gid,sid,name)=>{if(!confirm(`删除${name}？`))return;const r=await API.post("/api/groups/delete",{group_id:gid,steamid:sid});if(r.ok){toast("已删除");navigateTo("groups")}else toast(r.error||"失败","error")};
+window.addGroup=async()=>{const g=await pagePrompt("添加群聊","群号");if(!g)return;const r=await API.post("/api/groups/add-group",{group_id:g});if(r.ok){toast("已添加");navigateTo("groups")}else toast(r.error||"失败","error")};
+window.delGroup=async gid=>{if(!await pageConfirm(`删除群 ${gid}？`))return;const r=await API.post("/api/groups/delete-group",{group_id:gid});if(r.ok){toast("已删除");navigateTo("groups")}else toast(r.error||"失败","error")};
+window.addSteamID=async gid=>{const s=await pagePrompt(`向群 ${gid} 添加玩家`,"17 位 SteamID");if(!s)return;const r=await API.post("/api/groups/add",{group_id:gid,steamid:s});if(r.ok){toast("添加成功");navigateTo("groups")}else toast(r.error||"失败","error")};
+window.removeSteamID=async(gid,sid,name)=>{if(!await pageConfirm(`从群 ${gid} 删除 ${name}？`))return;const r=await API.post("/api/groups/delete",{group_id:gid,steamid:sid});if(r.ok){toast("已删除");navigateTo("groups")}else toast(r.error||"失败","error")};
 
 // ====== Bindings ======
 async function renderBindings(){
@@ -210,12 +315,12 @@ async function renderBindings(){
       <div class="form-group"><label class="form-label">SteamID</label><input id="bind-sid" class="form-input" placeholder="17位"></div>
       <div class="form-group"><label class="form-label">备注</label><input id="bind-nick" class="form-input"></div>
       <div class="modal-actions"><button class="btn" onclick="hideBindModal()">取消</button><button class="btn btn-primary" onclick="addBind()">确认</button></div></div></div>`;
-  function renderTable(){const t=document.getElementById("bind-tbody");if(!bs.length){t.innerHTML='<tr><td colspan="4" class="empty-state">暂无</td></tr>';return}t.innerHTML=bs.map(b=>`<tr><td>${b.qq}</td><td class="monospace">${b.steamid}</td><td>${b.nickname||"-"}</td><td><button class="btn btn-danger btn-sm" onclick="delBind('${b.qq}')">删除</button></td></tr>`).join("")}
+  function renderTable(){const t=document.getElementById("bind-tbody");if(!bs.length){t.innerHTML='<tr><td colspan="4" class="empty-state">暂无</td></tr>';return}t.innerHTML=bs.map(b=>`<tr><td>${escapeHtml(b.qq)}</td><td class="monospace">${escapeHtml(b.steamid)}</td><td>${escapeHtml(b.nickname||"-")}</td><td><button class="btn btn-danger btn-sm" onclick="delBind(${jsArg(b.qq)})">删除</button></td></tr>`).join("")}
   renderTable();
   window.showBindModal=()=>document.getElementById("bind-modal").classList.add("show");
   window.hideBindModal=()=>document.getElementById("bind-modal").classList.remove("show");
   window.addBind=async()=>{const q=document.getElementById("bind-qq").value,s=document.getElementById("bind-sid").value,n=document.getElementById("bind-nick").value;if(!q||!s){toast("必填","error");return}const r=await API.post("/api/bindings/add",{qq:q,steamid:s,nickname:n});if(r.ok){toast("成功");hideBindModal();navigateTo("bindings")}else toast(r.error||"失败","error")};
-  window.delBind=async qq=>{if(!confirm(`删除QQ${qq}？`))return;await API.post("/api/bindings/delete",{qq});toast("已删除");navigateTo("bindings")};
+  window.delBind=async qq=>{if(!await pageConfirm(`删除 QQ ${qq} 的绑定？`))return;await API.post("/api/bindings/delete",{qq});toast("已删除");navigateTo("bindings")};
 }
 
 // ====== Push & Settings ======
@@ -223,12 +328,13 @@ async function renderPush(){
   const d=await API.get("/api/push/settings");const c=document.getElementById("content");
   c.innerHTML=`<h2 class="page-title">每日推送设置</h2>
     <div class="card mb-20"><div class="card-title">推送时间</div><div class="flex gap-8" style="align-items:center"><input id="push-hour" class="form-input" type="number" min="0" max="23" value="${d.rank_push_hour}" style="width:80px"><span>时</span><input id="push-min" class="form-input" type="number" min="0" max="59" value="${d.rank_push_minute}" style="width:80px"><span>分</span><button class="btn btn-primary" onclick="updPush()">保存</button></div></div>
-    <div class="card"><div class="card-title">推送群聊</div><div class="form-group"><label class="flex gap-8" style="align-items:center;cursor:pointer"><label class="toggle"><input type="checkbox" ${d.rank_push_all?"checked":""} onchange="togAll(this.checked)"><span class="slider"></span></label><span>全群推送</span></label></div><div id="push-group-list"></div></div>`;
+    <div class="card mb-20"><div class="card-title">榜单内容范围</div><select id="push-rank-scope" class="form-input" onchange="setRankScope(this.value)" style="max-width:360px"><option value="group" ${d.rank_push_all?"":"selected"}>每个群独立统计本群玩家</option><option value="global" ${d.rank_push_all?"selected":""}>所有目标群共享全局榜单</option></select><p class="permission-help" style="margin-top:8px">默认使用分群榜单；只有显式选择全局模式时，目标群才会收到同一张总榜。</p></div>
+    <div class="card"><div class="card-title">接收每日榜单的群聊</div><div id="push-group-list"></div></div>`;
   const allG=d.all_groups||[],pushG=d.rank_push_groups||[];
-  document.getElementById("push-group-list").innerHTML=allG.map(gid=>`<div class="form-group" style="margin-bottom:8px"><label class="flex gap-8" style="align-items:center;cursor:pointer"><label class="toggle"><input type="checkbox" ${pushG.includes(gid)?"checked":""} onchange="togGroup('${gid}',this.checked)"><span class="slider"></span></label><span>群${gid}</span></label></div>`).join("");
+  document.getElementById("push-group-list").innerHTML=allG.map(gid=>`<div class="form-group" style="margin-bottom:8px"><label class="flex gap-8" style="align-items:center;cursor:pointer"><label class="toggle"><input type="checkbox" ${pushG.includes(gid)?"checked":""} onchange="togGroup(${jsArg(gid)},this.checked)"><span class="slider"></span></label><span>群${escapeHtml(gid)}</span></label></div>`).join("");
   window.updPush=async()=>{const h=parseInt(document.getElementById("push-hour").value),m=parseInt(document.getElementById("push-min").value);await API.post("/api/push/update",{rank_push_hour:h,rank_push_minute:m});toast("已更新")};
   window.togGroup=async(gid,on)=>{await API.post(on?"/api/push/groups/add":"/api/push/groups/remove",{group_id:gid})};
-  window.togAll=async()=>{const r=await API.post("/api/push/all/toggle",{});toast(`全群推送${r.rank_push_all?"已开启":"已关闭"}`)};
+  window.setRankScope=async scope=>{await API.post("/api/push/rank-scope",{scope});toast(scope==="group"?"已切换为每群独立榜单":"已切换为共享全局榜单")};
 }
 // ====== Command Permissions ======
 async function loadPermissionSettings(){
@@ -249,12 +355,23 @@ async function loadPermissionSettings(){
     }));
   }catch(error){body.innerHTML=`<div class="empty-state"><span class="mdi mdi-alert-circle"></span><p>权限加载失败：${escapeHtml(error.message)}</p><button class="btn btn-primary mt-8" onclick="loadPermissionSettings()">重试</button></div>`}
 }
-function escapeHtml(value){const div=document.createElement("div");div.textContent=String(value);return div.innerHTML}
+function escapeHtml(value){const div=document.createElement("div");div.textContent=String(value??"");return div.innerHTML}
+function escapeAttr(value){return escapeHtml(value).replace(/"/g,"&quot;").replace(/'/g,"&#39;").replace(/`/g,"&#96;")}
+function jsArg(value){return escapeAttr(JSON.stringify(String(value??"")))}
+function safeImageUrl(value){
+  const url=String(value||"").trim();
+  if(/^data:image\/[a-z0-9.+-]+;base64,/i.test(url))return escapeAttr(url);
+  try{
+    const parsed=new URL(url);
+    if(parsed.protocol==="https:"||parsed.protocol==="http:")return escapeAttr(url)
+  }catch(_){}
+  return""
+}
 
-const SL={steam_api_key:"Steam Web API密钥",sgdb_api_key:"SteamGridDB API密钥",fixed_poll_interval:"固定轮询间隔(秒)",smart_poll_intervals:"智能轮询间隔(分)",retry_times:"API重试次数",max_group_size:"单群最大监控人数",detailed_poll_log:"详细轮询日志",enable_achievement_poll:"成就轮询推送",enable_game_end_notify:"游戏结束通知",notify_send_image:"通知发送图片",notify_send_text:"通知发送文本",enable_proxy:"启用代理",proxy_url:"代理链接",cache_avatar_hours:"头像缓存(小时)",cache_avatar_frame_hours:"头像框缓存(小时)",game_filter_mode:"游戏过滤模式",game_filter_ids:"过滤游戏ID",web_port:"管理后台端口",rank_push_hour:"推送-时",rank_push_minute:"推送-分"};
-const SO=["steam_api_key","sgdb_api_key","web_port","fixed_poll_interval","smart_poll_intervals","retry_times","max_group_size","enable_game_end_notify","enable_achievement_poll","notify_send_text","notify_send_image","detailed_poll_log","game_filter_mode","game_filter_ids","rank_push_hour","rank_push_minute","enable_proxy","proxy_url","cache_avatar_hours","cache_avatar_frame_hours"];
+const SL={steam_api_key:"Steam Web API密钥",sgdb_api_key:"SteamGridDB API密钥",fixed_poll_interval:"固定轮询间隔(秒)",smart_poll_intervals:"智能轮询间隔(分)",retry_times:"API重试次数",max_group_size:"单群最大监控人数",detailed_poll_log:"详细轮询日志",enable_achievement_poll:"成就轮询推送",enable_game_end_notify:"游戏结束通知",notify_send_image:"通知发送图片",notify_send_text:"通知发送文本",enable_proxy:"启用代理",proxy_url:"代理链接",cache_avatar_hours:"头像缓存(小时)",cache_avatar_frame_hours:"头像框缓存(小时)",game_filter_mode:"游戏过滤模式",game_filter_ids:"过滤游戏ID",rank_push_hour:"推送-时",rank_push_minute:"推送-分"};
+const SO=["steam_api_key","sgdb_api_key","fixed_poll_interval","smart_poll_intervals","retry_times","max_group_size","enable_game_end_notify","enable_achievement_poll","notify_send_text","notify_send_image","detailed_poll_log","game_filter_mode","game_filter_ids","rank_push_hour","rank_push_minute","enable_proxy","proxy_url","cache_avatar_hours","cache_avatar_frame_hours"];
 const BK=["detailed_poll_log","enable_achievement_poll","enable_game_end_notify","notify_send_image","notify_send_text"];
-const IK=["fixed_poll_interval","retry_times","max_group_size","cache_avatar_hours","cache_avatar_frame_hours","web_port","rank_push_hour","rank_push_minute"];
+const IK=["fixed_poll_interval","retry_times","max_group_size","cache_avatar_hours","cache_avatar_frame_hours","rank_push_hour","rank_push_minute"];
 const SK=["smart_poll_intervals","proxy_url","game_filter_ids"];const SEK=["steam_api_key","sgdb_api_key"];
 async function renderSettings(){
   const data=await API.get("/api/settings");const c=document.getElementById("content");
@@ -263,8 +380,8 @@ async function renderSettings(){
     if(SEK.includes(k))h+=`<div class="form-group"><label class="form-label">${l}</label><input id="cfg-${k}" class="form-input" type="password"></div>`;
     else if(k==="game_filter_mode"){h+=`<div class="form-group"><label class="form-label">${l}</label><select id="cfg-${k}" class="form-input">${["全部游戏","白名单","黑名单"].map(m=>`<option ${data.game_filter_mode===m?"selected":""}>${m}</option>`).join("")}</select></div>`}
     else if(BK.includes(k))h+=`<div class="form-group"><label class="flex gap-8" style="align-items:center;cursor:pointer"><label class="toggle"><input type="checkbox" id="cfg-${k}" ${data[k]?"checked":""}><span class="slider"></span></label><span>${l}</span></label></div>`;
-    else if(IK.includes(k))h+=`<div class="form-group"><label class="form-label">${l}</label><input id="cfg-${k}" class="form-input" type="number" value="${data[k]??""}"></div>`;
-    else h+=`<div class="form-group"><label class="form-label">${l}</label><input id="cfg-${k}" class="form-input" value="${data[k]??""}"></div>`}
+    else if(IK.includes(k))h+=`<div class="form-group"><label class="form-label">${l}</label><input id="cfg-${k}" class="form-input" type="number" value="${escapeAttr(data[k]??"")}"></div>`;
+    else h+=`<div class="form-group"><label class="form-label">${l}</label><input id="cfg-${k}" class="form-input" value="${escapeAttr(data[k]??"")}"></div>`}
   h+='<button class="btn btn-primary mt-8" onclick="saveSet()">保存全部设置</button></div>';
   h+=`<details class="card settings-collapsible" id="permission-settings"><summary><span><span class="mdi mdi-shield-account"></span> 指令权限</span><span class="summary-hint">按指令设置 admin / member</span></summary><div id="permission-settings-body" class="collapsible-body"><p class="permission-help">展开后读取 AstrBot 当前权限配置。</p></div></details>`;
   c.innerHTML=h;
@@ -289,10 +406,48 @@ window.runSteamTest=async()=>{
   document.getElementById("test-sgdb-result").innerHTML='<div style="grid-column:1/-1;text-align:center;padding:16px;color:var(--text-muted)"><span class="mdi mdi-loading mdi-spin" style="font-size:24px"></span><p style="margin-top:8px">测试中...</p></div>';
   try{
     const r=await API.get("/api/test/steam");
-    document.getElementById("test-steam-result").innerHTML=["steam_api","steam_store","cover_horizontal"].map(k=>`<div class="test-stat"><div class="test-stat-val" style="color:${r[k]==="ok"?"var(--accent-green)":"var(--accent-red)"}">${r[k]}</div><div class="test-stat-lbl">${k}</div></div>`).join("");
-    document.getElementById("test-sgdb-result").innerHTML=["sgdb","sgdb_cover"].map(k=>`<div class="test-stat"><div class="test-stat-val" style="color:${r[k]==="ok"?"var(--accent-green)":"var(--accent-red)"}">${r[k]}</div><div class="test-stat-lbl">${k}</div></div>`).join("");
-  }catch(e){document.getElementById("test-steam-result").innerHTML=`<span style="color:var(--accent-red)">${e.message}</span>`}
+    document.getElementById("test-steam-result").innerHTML=["steam_api","steam_store","cover_horizontal"].map(k=>`<div class="test-stat"><div class="test-stat-val" style="color:${r[k]==="ok"?"var(--accent-green)":"var(--accent-red)"}">${escapeHtml(r[k])}</div><div class="test-stat-lbl">${k}</div></div>`).join("");
+    document.getElementById("test-sgdb-result").innerHTML=["sgdb","sgdb_cover"].map(k=>`<div class="test-stat"><div class="test-stat-val" style="color:${r[k]==="ok"?"var(--accent-green)":"var(--accent-red)"}">${escapeHtml(r[k])}</div><div class="test-stat-lbl">${k}</div></div>`).join("");
+  }catch(e){document.getElementById("test-steam-result").innerHTML=`<span style="color:var(--accent-red)">${escapeHtml(e.message)}</span>`}
 };
-window.runSidTest=async()=>{const sid=document.getElementById("test-sid-input").value.trim();if(!sid||sid.length!==17){toast("输入17位SteamID","error");return}const rs=document.getElementById("test-sid-result");rs.innerHTML='<span style="color:var(--text-muted)">查询中...</span>';try{const r=await API.get(`/api/test/steamid/${sid}`);if(r.from_cache||r.from_api){const pl=r.player||r;rs.innerHTML=`<div style="display:flex;gap:12px;padding:16px;background:var(--bg-primary);border-radius:var(--border-radius-lg);border:1px solid var(--border-color)"><img src="${pl.avatar||r.avatar}" style="width:56px;height:56px;border-radius:8px;background:var(--bg-tertiary)" onerror="this.style.display='none'"><div><div style="font-size:15px;font-weight:500;color:var(--text-bright)">${pl.name||r.name||sid}</div><div style="font-size:12px;color:var(--text-muted)">${sid}</div>${pl.gameextrainfo||r.game?`<div style="font-size:12px;color:var(--accent-green);margin-top:4px">🎮${pl.gameextrainfo||r.game}</div>`:""}<div style="font-size:11px;color:var(--text-muted);margin-top:4px">来源:${r.from_cache?"本地缓存":"Steam API"}</div></div></div>`}else rs.innerHTML=`<span style="color:var(--accent-red)">${r.error||"查询失败"}</span>`}catch(e){rs.innerHTML=`<span style="color:var(--accent-red)">${e.message}</span>`}};
+window.runSidTest=async()=>{
+  const sid=document.getElementById("test-sid-input").value.trim();
+  if(!/^\d{17}$/.test(sid)){toast("输入17位SteamID","error");return}
+  const rs=document.getElementById("test-sid-result");
+  rs.innerHTML='<span style="color:var(--text-muted)">查询中...</span>';
+  try{
+    const r=await API.get(`/api/test/steamid/${sid}`);
+    if(r.from_cache||r.from_api){
+      const pl=r.player||r;
+      const avatar=safeImageUrl(pl.avatar||r.avatar);
+      const name=escapeHtml(pl.name||r.name||sid);
+      const game=pl.gameextrainfo||r.game;
+      rs.innerHTML=`<div style="display:flex;gap:12px;padding:16px;background:var(--bg-primary);border-radius:var(--border-radius-lg);border:1px solid var(--border-color)"><img src="${avatar}" style="width:56px;height:56px;border-radius:8px;background:var(--bg-tertiary)" onerror="this.style.display='none'"><div><div style="font-size:15px;font-weight:500;color:var(--text-bright)">${name}</div><div style="font-size:12px;color:var(--text-muted)">${escapeHtml(sid)}</div>${game?`<div style="font-size:12px;color:var(--accent-green);margin-top:4px">🎮${escapeHtml(game)}</div>`:""}<div style="font-size:11px;color:var(--text-muted);margin-top:4px">来源:${r.from_cache?"本地缓存":"Steam API"}</div></div></div>`
+    }else{
+      rs.innerHTML=`<span style="color:var(--accent-red)">${escapeHtml(r.error||"查询失败")}</span>`
+    }
+  }catch(e){
+    rs.innerHTML=`<span style="color:var(--accent-red)">${escapeHtml(e.message)}</span>`
+  }
+};
 
-navigateTo("dashboard");
+function applyBridgeContext(context) {
+  document.documentElement.dataset.theme = context?.isDark ? "dark" : "light";
+}
+
+async function initPluginPage() {
+  if (!bridge) {
+    throw new Error("AstrBot Plugin Page bridge is unavailable");
+  }
+  const context = await bridge.ready();
+  applyBridgeContext(context);
+  bridge.onContext?.(applyBridgeContext);
+  await navigateTo("dashboard");
+}
+
+initPluginPage().catch((error) => {
+  const content = document.getElementById("content");
+  if (content) {
+    content.innerHTML = `<div class="empty-state"><span class="mdi mdi-alert-circle"></span><p>页面初始化失败: ${escapeHtml(error.message)}</p></div>`;
+  }
+});

--- a/pages/steam-monitor/index.html
+++ b/pages/steam-monitor/index.html
@@ -6,7 +6,7 @@
 <title>Steam Monitor Admin</title>
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.3.67/css/materialdesignicons.min.css">
-<link rel="stylesheet" href="/static/style.css?v=3.2.2">
+<link rel="stylesheet" href="./style.css">
 </head>
 <body>
 <div id="app">
@@ -37,6 +37,20 @@
   </div>
 </div>
 <div id="hplayer-tooltip" class="player-tooltip" style="display:none;position:fixed;z-index:200;background:var(--bg-card);border:1px solid var(--border-color);border-radius:var(--border-radius-lg);padding:16px;min-width:240px;box-shadow:0 8px 24px rgba(0,0,0,0.5);pointer-events:none"></div>
-<script src="/static/app.js?v=3.2.2"></script>
+<div id="page-dialog" class="modal-overlay">
+  <div class="modal">
+    <div id="page-dialog-title" class="modal-title"></div>
+    <div id="page-dialog-input-wrap" class="form-group">
+      <label id="page-dialog-label" class="form-label"></label>
+      <input id="page-dialog-input" class="form-input">
+    </div>
+    <div class="modal-actions">
+      <button class="btn" onclick="resolvePageDialog(false)">取消</button>
+      <button class="btn btn-primary" onclick="resolvePageDialog(true)">确认</button>
+    </div>
+  </div>
+</div>
+<script src="/api/plugin/page/bridge-sdk.js"></script>
+<script src="./app.js"></script>
 </body>
 </html>

--- a/pages/steam-monitor/style.css
+++ b/pages/steam-monitor/style.css
@@ -20,6 +20,25 @@
   --border-radius: 6px;
   --border-radius-lg: 10px;
 }
+[data-theme="light"] {
+  --bg-page: #f4f7fa;
+  --bg-primary: #ffffff;
+  --bg-secondary: #eef3f7;
+  --bg-tertiary: #dce8f0;
+  --bg-card: #ffffff;
+  --bg-hover: #cbdde9;
+  --text-primary: #1f3444;
+  --text-secondary: #526b7d;
+  --text-muted: #7b8f9d;
+  --text-bright: #142635;
+  --accent: #2677a5;
+  --accent-hover: #1d658f;
+  --accent-green: #668500;
+  --accent-red: #c63f3f;
+  --accent-orange: #b36d12;
+  --accent-yellow: #8d7717;
+  --border-color: #cddbe5;
+}
 * { margin:0; padding:0; box-sizing:border-box; }
 body {
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Noto Sans SC",sans-serif;

--- a/rank_push.py
+++ b/rank_push.py
@@ -1,0 +1,23 @@
+"""Small, dependency-free helpers for scheduled ranking delivery."""
+
+
+def build_rank_push_scopes(group_ids, use_global_rank=False):
+    """Return ``(target_group, data_group)`` pairs for a scheduled push.
+
+    ``data_group`` is the target group in the normal per-group mode and
+    ``None`` only when the administrator explicitly selected a shared global
+    ranking. Group IDs are normalized to strings and duplicates are removed
+    while preserving their configured order.
+    """
+
+    scopes = []
+    seen = set()
+    for raw_group_id in group_ids or []:
+        if raw_group_id is None:
+            continue
+        group_id = str(raw_group_id).strip()
+        if not group_id or group_id in seen:
+            continue
+        seen.add(group_id)
+        scopes.append((group_id, None if use_global_rank else group_id))
+    return scopes

--- a/tests/test_rank_push.py
+++ b/tests/test_rank_push.py
@@ -1,0 +1,27 @@
+import unittest
+
+from rank_push import build_rank_push_scopes
+
+
+class RankPushScopeTests(unittest.TestCase):
+    def test_default_mode_uses_each_target_group_as_its_data_scope(self):
+        self.assertEqual(
+            build_rank_push_scopes(["group-a", "group-b"]),
+            [("group-a", "group-a"), ("group-b", "group-b")],
+        )
+
+    def test_global_mode_is_explicit_and_keeps_delivery_targets(self):
+        self.assertEqual(
+            build_rank_push_scopes(["group-a", "group-b"], use_global_rank=True),
+            [("group-a", None), ("group-b", None)],
+        )
+
+    def test_group_ids_are_normalized_and_deduplicated(self):
+        self.assertEqual(
+            build_rank_push_scopes([123, "123", "", None, " 456 "]),
+            [("123", "123"), ("456", "456")],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,5 +1,0 @@
-# -*- coding: utf-8 -*-
-"""Steam Status Monitor - Web Admin Dashboard"""
-from .server import WebAdminServer
-
-__all__ = ["WebAdminServer"]

--- a/web_api.py
+++ b/web_api.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
-"""aiohttp HTTP Server for Steam Monitor Admin Dashboard"""
-import os
+"""AstrBot Plugin Pages API for the Steam Monitor dashboard."""
 import asyncio
+import base64
 import logging
-from aiohttp import web
+import mimetypes
+import os
+from functools import wraps
+
+from astrbot.api.web import error_response, json_response, request
 from astrbot.core.star.command_management import (
     list_commands,
     update_command_permission,
@@ -11,13 +15,13 @@ from astrbot.core.star.command_management import (
 
 # 尝试导入父包的工具函数（运行时可能因 AstrBot 加载机制失败，优雅降级）
 try:
-    from ..rank_render import render_rank_image
+    from .rank_render import render_rank_image
 except ImportError:
     render_rank_image = None
 
 logger = logging.getLogger(__name__)
 
-STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
+PLUGIN_NAME = "steam_status_monitor_V3"
 
 
 def _get_player_display_name(p, sid):
@@ -80,111 +84,92 @@ def _command_descriptor_to_dict(descriptor):
     }
 
 
+class _PluginPageRequest:
+    """Expose the subset of aiohttp's request API used by the legacy handlers."""
+
+    @property
+    def query(self):
+        return request.query
+
+    @property
+    def match_info(self):
+        return request.path_params or {}
+
+    async def json(self):
+        payload = await request.json(default=None)
+        if not isinstance(payload, dict):
+            raise ValueError("request body must be a JSON object")
+        return payload
+
+
 def safe_api(handler):
-    """装饰器：捕获 API handler 中的异常，统一返回 JSON 错误"""
-    async def wrapper(*args, **kwargs):
+    """Catch handler failures and return a consistent Plugin Pages error."""
+
+    @wraps(handler)
+    async def wrapper(*_args, **_kwargs):
         try:
-            resp = await handler(*args, **kwargs)
-            # 所有 API 响应禁止浏览器缓存
-            if isinstance(resp, web.StreamResponse) and hasattr(resp, 'headers'):
-                resp.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
-                resp.headers['Pragma'] = 'no-cache'
-                resp.headers['Expires'] = '0'
-            return resp
+            return await handler(_PluginPageRequest())
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.error(f"[WebAdmin] API 异常 {handler.__name__}: {e}", exc_info=True)
-            return web.json_response({"error": str(e), "handler": handler.__name__}, status=500)
-    # Preserve the original name for route registration
-    wrapper.__name__ = handler.__name__
+            logger.error(
+                f"[WebAdmin] API 异常 {handler.__name__}: {e}",
+                exc_info=True,
+            )
+            return error_response(str(e), status_code=500)
+
     return wrapper
 
 
-class WebAdminServer:
-    """嵌入式 HTTP 管理后台服务器，运行在独立端口（默认 6195）"""
+class WebAdminAPI:
+    """Backend API registered into AstrBot's authenticated Dashboard."""
 
-    def __init__(self, plugin_instance, port=6195):
+    def __init__(self, plugin_instance):
         self.plugin = plugin_instance
-        self.port = port
-        self.app = web.Application()
-        self.runner = None
-        self._setup_routes()
 
-    def _setup_routes(self):
-        """注册路由：静态文件 + REST API"""
-        self.app["plugin"] = self.plugin
+    def register_routes(self, context):
+        """Register all routes used by ``pages/steam-monitor``."""
+
         def r(method, path, handler):
-            self.app.router.add_route(method, path, safe_api(handler))
+            context.register_web_api(
+                f"/{PLUGIN_NAME}{path}",
+                safe_api(handler),
+                [method],
+                f"Steam Monitor Page: {handler.__name__}",
+            )
 
-        # 静态首页
-        self.app.router.add_get("/", self._serve_index)
-        self.app.router.add_get("/index.html", self._serve_index)
-
-        # 静态资源
-        self.app.router.add_static("/static", STATIC_DIR, show_index=False)
-
-        # REST API 端点（使用 r 注册自动添加异常捕获）
-        r("GET", "/api/dashboard/stats", self._api_dashboard_stats)
-        r("GET", "/api/dashboard/rank-image", self._api_dashboard_rank_image)
-        r("GET", "/api/gantt/data", self._api_gantt_data)
-        r("GET", "/api/heatmap/data", self._api_heatmap_data)
-        r("GET", "/api/heatmap/player/{steamid}", self._api_heatmap_player)
-        r("GET", "/api/groups", self._api_groups_list)
-        r("POST", "/api/groups/add", self._api_groups_add)
-        r("POST", "/api/groups/delete", self._api_groups_delete)
-        r("POST", "/api/groups/add-group", self._api_groups_add_group)
-        r("POST", "/api/groups/delete-group", self._api_groups_delete_group)
-        r("GET", "/api/groups/{group_id}/players", self._api_group_players)
-        r("GET", "/api/bindings", self._api_bindings_list)
-        r("POST", "/api/bindings/add", self._api_bindings_add)
-        r("POST", "/api/bindings/delete", self._api_bindings_delete)
-        r("POST", "/api/bindings/update", self._api_bindings_update)
-        r("GET", "/api/push/settings", self._api_push_settings)
-        r("POST", "/api/push/update", self._api_push_update)
-        r("POST", "/api/push/groups/add", self._api_push_group_add)
-        r("POST", "/api/push/groups/remove", self._api_push_group_remove)
-        r("POST", "/api/push/all/toggle", self._api_push_all_toggle)
-        r("GET", "/api/settings", self._api_settings_get)
-        r("POST", "/api/settings/update", self._api_settings_update)
-        r("GET", "/api/permissions", self._api_permissions_list)
-        r("POST", "/api/permissions/update", self._api_permissions_update)
-        r("GET", "/api/players/search", self._api_players_search)
-        r("GET", "/api/players/avatar/{steamid}", self._api_player_avatar)
-        r("GET", "/api/players/info/{steamid}", self._api_player_info)
-        r("GET", "/api/games/cover/{gameid}", self._api_game_cover)
-        r("GET", "/api/test/steam", self._api_test_steam)
-        r("GET", "/api/test/cover", self._api_test_cover)
-        r("GET", "/api/test/steamid/{steamid}", self._api_test_steamid)
-
-    async def start(self):
-        """启动 HTTP 服务器"""
-        self.runner = web.AppRunner(self.app)
-        await self.runner.setup()
-        site = web.TCPSite(self.runner, "127.0.0.1", self.port)
-        await site.start()
-        url = f"http://127.0.0.1:{self.port}"
-        logger.info(f"[WebAdmin] 管理后台已启动: {url}")
-        print(f"\n{'='*60}")
-        print(f"  Steam 状态监控 - Web 管理后台")
-        print(f"  请使用浏览器访问: {url}")
-        print(f"{'='*60}\n")
-
-    async def stop(self):
-        """停止 HTTP 服务器"""
-        if self.runner:
-            await self.runner.cleanup()
-            logger.info("[WebAdmin] 管理后台已停止")
-
-    async def _serve_index(self, request):
-        """返回首页 HTML"""
-        index_path = os.path.join(STATIC_DIR, "index.html")
-        if os.path.exists(index_path):
-            return web.FileResponse(index_path)
-        return web.Response(
-            text="<h1>Server running</h1><p>index.html not found yet</p>",
-            content_type="text/html",
-        )
+        # Plugin-local endpoints. The Page bridge adds the plugin prefix.
+        r("GET", "/dashboard/stats", self._api_dashboard_stats)
+        r("GET", "/dashboard/rank-image", self._api_dashboard_rank_image)
+        r("GET", "/gantt/data", self._api_gantt_data)
+        r("GET", "/heatmap/data", self._api_heatmap_data)
+        r("GET", "/heatmap/player/<steamid>", self._api_heatmap_player)
+        r("GET", "/groups", self._api_groups_list)
+        r("POST", "/groups/add", self._api_groups_add)
+        r("POST", "/groups/delete", self._api_groups_delete)
+        r("POST", "/groups/add-group", self._api_groups_add_group)
+        r("POST", "/groups/delete-group", self._api_groups_delete_group)
+        r("GET", "/groups/<group_id>/players", self._api_group_players)
+        r("GET", "/bindings", self._api_bindings_list)
+        r("POST", "/bindings/add", self._api_bindings_add)
+        r("POST", "/bindings/delete", self._api_bindings_delete)
+        r("POST", "/bindings/update", self._api_bindings_update)
+        r("GET", "/push/settings", self._api_push_settings)
+        r("POST", "/push/update", self._api_push_update)
+        r("POST", "/push/groups/add", self._api_push_group_add)
+        r("POST", "/push/groups/remove", self._api_push_group_remove)
+        r("POST", "/push/rank-scope", self._api_push_rank_scope)
+        r("GET", "/settings", self._api_settings_get)
+        r("POST", "/settings/update", self._api_settings_update)
+        r("GET", "/permissions", self._api_permissions_list)
+        r("POST", "/permissions/update", self._api_permissions_update)
+        r("GET", "/players/search", self._api_players_search)
+        r("GET", "/players/avatar/<steamid>", self._api_player_avatar)
+        r("GET", "/players/info/<steamid>", self._api_player_info)
+        r("GET", "/games/cover/<gameid>", self._api_game_cover)
+        r("GET", "/test/steam", self._api_test_steam)
+        r("GET", "/test/cover", self._api_test_cover)
+        r("GET", "/test/steamid/<steamid>", self._api_test_steamid)
 
     def _is_plugin_command(self, command):
         if command.get("plugin") == "steam_status_monitor_V3":
@@ -201,15 +186,16 @@ class WebAdminServer:
 
     async def _api_permissions_list(self, request):
         commands = await self._plugin_commands()
-        return web.json_response({"commands": commands})
+        return json_response({"commands": commands})
 
     async def _api_permissions_update(self, request):
         data = await request.json()
         handler_full_name = str(data.get("handler_full_name") or "").strip()
         permission = str(data.get("permission") or "").strip().lower()
         if permission not in {"admin", "member"}:
-            return web.json_response(
-                {"error": "permission 只允许 admin 或 member"}, status=400
+            return json_response(
+                {"error": "permission 只允许 admin 或 member"},
+                status_code=400,
             )
 
         commands = await self._plugin_commands()
@@ -217,12 +203,13 @@ class WebAdminServer:
             command.get("handler_full_name") == handler_full_name
             for command in commands
         ):
-            return web.json_response(
-                {"error": "指定指令不属于本插件"}, status=404
+            return json_response(
+                {"error": "指定指令不属于本插件"},
+                status_code=404,
             )
 
         descriptor = await update_command_permission(handler_full_name, permission)
-        return web.json_response({
+        return json_response({
             "ok": True,
             "command": _command_descriptor_to_dict(descriptor),
         })
@@ -296,7 +283,7 @@ class WebAdminServer:
                     "avatar_url": state.get("avatarfull") or state.get("avatar", ""),
                 })
 
-        return web.json_response({
+        return json_response({
             "total_groups": total_groups,
             "total_players": total_players,
             "total_bindings": total_bindings,
@@ -314,7 +301,10 @@ class WebAdminServer:
         """生成排行榜图片（参考 rank_render 渲染方式，使用本地缓存的封面/头像）"""
         p = self.plugin
         if not render_rank_image:
-            return web.json_response({"error": "rank_render not available"}, status=500)
+            return json_response(
+                {"error": "rank_render not available"},
+                status_code=500,
+            )
 
         from datetime import datetime, timedelta
         try:
@@ -366,7 +356,7 @@ class WebAdminServer:
 
         rank_data = sorted(player_agg.values(), key=lambda x: -x["total_minutes"])[:25]
         if not rank_data:
-            return web.json_response({"error": "no data"}, status=404)
+            return json_response({"error": "no data"}, status_code=404)
 
         # 补充头像 URL 和 top_game_id（与 rank 指令完全一致的渲染方式）
         avatar_map = {}
@@ -395,9 +385,11 @@ class WebAdminServer:
             if fp:
                 font_path = fp("NotoSansHans-Regular.otf")
             if not font_path:
-                import os as _os
-                base = _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__)))
-                font_path = _os.path.join(base, "fonts", "NotoSansHans-Regular.otf")
+                font_path = os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "fonts",
+                    "NotoSansHans-Regular.otf",
+                )
         except Exception:
             pass
 
@@ -409,10 +401,14 @@ class WebAdminServer:
                 proxy=getattr(p, "proxy", None),
                 cover_fetcher=cover_fetcher,
             )
-            return web.Response(body=img_bytes, content_type="image/png")
+            encoded = base64.b64encode(img_bytes).decode("ascii")
+            return json_response({"data_url": f"data:image/png;base64,{encoded}"})
         except Exception as e:
             logger.error(f"[WebAdmin] rank_image 渲染失败: {e}", exc_info=True)
-            return web.json_response({"error": f"render failed: {e}"}, status=500)
+            return json_response(
+                {"error": f"render failed: {e}"},
+                status_code=500,
+            )
 
     # ────── Gantt ──────
 
@@ -529,7 +525,7 @@ class WebAdminServer:
         except Exception:
             pass
 
-        return web.json_response({
+        return json_response({
             "players": players,
             "time_range": {
                 "start": range_start.strftime("%Y-%m-%d %H:%M"),
@@ -608,7 +604,7 @@ class WebAdminServer:
             key=lambda x: -x["total_minutes"],
         )
 
-        return web.json_response({
+        return json_response({
             "heatmap_data": heatmap_daily,
             "players": players,
         })
@@ -695,7 +691,7 @@ class WebAdminServer:
             key=lambda x: -x["minutes"],
         )[:10]
 
-        return web.json_response({
+        return json_response({
             "sid": steamid,
             "name": name,
             "heatmap_daily": heatmap_daily,
@@ -724,47 +720,56 @@ class WebAdminServer:
                     "game": last_state.get("gameextrainfo", ""),
                     "personastate": last_state.get("personastate", 0),
                 })
-        return web.json_response({"groups": result})
+        return json_response({"groups": result})
 
     async def _api_groups_add(self, request):
         p = self.plugin
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         gid = str(data.get("group_id", ""))
         sid = str(data.get("steamid", ""))
         if not gid or not sid or not sid.isdigit() or len(sid) != 17:
-            return web.json_response({"error": "invalid group_id or steamid"}, status=400)
+            return json_response(
+                {"error": "invalid group_id or steamid"},
+                status_code=400,
+            )
         groups = getattr(p, "group_steam_ids", {})
         if gid not in groups:
             groups[gid] = []
         if sid in groups[gid]:
-            return web.json_response({"ok": True, "message": "already exists"})
+            return json_response({"ok": True, "message": "already exists"})
         max_size = getattr(p, "max_group_size", 20)
         if len(groups[gid]) >= max_size:
-            return web.json_response({"error": f"group limit reached ({max_size})"}, status=400)
+            return json_response(
+                {"error": f"group limit reached ({max_size})"},
+                status_code=400,
+            )
         groups[gid].append(sid)
         p._save_group_steam_ids()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
     async def _api_groups_delete(self, request):
         p = self.plugin
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         gid = str(data.get("group_id", ""))
         sid = str(data.get("steamid", ""))
         if not gid or not sid:
-            return web.json_response({"error": "invalid group_id or steamid"}, status=400)
+            return json_response(
+                {"error": "invalid group_id or steamid"},
+                status_code=400,
+            )
         groups = getattr(p, "group_steam_ids", {}) or {}
         if gid in groups and sid in groups[gid]:
             groups[gid].remove(sid)
             if not groups[gid]:
                 del groups[gid]
             p._save_group_steam_ids()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
     async def _api_groups_add_group(self, request):
         """新增一个空群聊"""
@@ -772,16 +777,16 @@ class WebAdminServer:
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         gid = str(data.get("group_id", "")).strip()
         if not gid:
-            return web.json_response({"error": "invalid group_id"}, status=400)
+            return json_response({"error": "invalid group_id"}, status_code=400)
         groups = getattr(p, "group_steam_ids", {})
         if gid in groups:
-            return web.json_response({"ok": True, "message": "already exists"})
+            return json_response({"ok": True, "message": "already exists"})
         groups[gid] = []
         p._save_group_steam_ids()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
     async def _api_groups_delete_group(self, request):
         """删除一个群聊及其所有 SteamID"""
@@ -789,15 +794,15 @@ class WebAdminServer:
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         gid = str(data.get("group_id", "")).strip()
         if not gid:
-            return web.json_response({"error": "invalid group_id"}, status=400)
+            return json_response({"error": "invalid group_id"}, status_code=400)
         groups = getattr(p, "group_steam_ids", {}) or {}
         if gid in groups:
             del groups[gid]
             p._save_group_steam_ids()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
     async def _api_group_players(self, request):
         p = self.plugin
@@ -816,7 +821,7 @@ class WebAdminServer:
                 "game": state.get("gameextrainfo", ""),
                 "personastate": state.get("personastate", 0),
             })
-        return web.json_response({"group_id": group_id, "players": result})
+        return json_response({"group_id": group_id, "players": result})
 
     # ────── Bindings ──────
 
@@ -830,53 +835,56 @@ class WebAdminServer:
                 "steamid": info.get("sid", ""),
                 "nickname": info.get("nickname", ""),
             })
-        return web.json_response({"bindings": result})
+        return json_response({"bindings": result})
 
     async def _api_bindings_add(self, request):
         p = self.plugin
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         qq = str(data.get("qq", ""))
         sid = str(data.get("steamid", ""))
         nickname = str(data.get("nickname", ""))
         if not qq or not sid:
-            return web.json_response({"error": "qq and steamid required"}, status=400)
+            return json_response(
+                {"error": "qq and steamid required"},
+                status_code=400,
+            )
         p._bind_data[qq] = {"sid": sid, "nickname": nickname}
         p._save_bind_data()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
     async def _api_bindings_delete(self, request):
         p = self.plugin
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         qq = str(data.get("qq", ""))
         if qq in p._bind_data:
             del p._bind_data[qq]
             p._save_bind_data()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
     async def _api_bindings_update(self, request):
         p = self.plugin
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         qq = str(data.get("qq", ""))
         nickname = str(data.get("nickname", ""))
         if qq in p._bind_data:
             p._bind_data[qq]["nickname"] = nickname
             p._save_bind_data()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
     # ────── Push Settings ──────
 
     async def _api_push_settings(self, request):
         p = self.plugin
-        return web.json_response({
+        return json_response({
             "rank_push_hour": getattr(p, "rank_push_hour", 8),
             "rank_push_minute": getattr(p, "rank_push_minute", 30),
             "rank_push_groups": getattr(p, "rank_push_groups", []),
@@ -889,43 +897,72 @@ class WebAdminServer:
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
-        p.rank_push_hour = data.get("rank_push_hour", p.rank_push_hour)
-        p.rank_push_minute = data.get("rank_push_minute", p.rank_push_minute)
+            return json_response({"error": "invalid JSON"}, status_code=400)
+        try:
+            hour = int(data.get("rank_push_hour", p.rank_push_hour))
+            minute = int(data.get("rank_push_minute", p.rank_push_minute))
+        except (TypeError, ValueError):
+            return json_response(
+                {"error": "invalid push time"},
+                status_code=400,
+            )
+        if not 0 <= hour <= 23 or not 0 <= minute <= 59:
+            return json_response(
+                {"error": "push time out of range"},
+                status_code=400,
+            )
+        p.rank_push_hour = hour
+        p.rank_push_minute = minute
         p.config["rank_push_hour"] = p.rank_push_hour
         p.config["rank_push_minute"] = p.rank_push_minute
-        return web.json_response({"ok": True})
+        if hasattr(p.config, "save_config"):
+            p.config.save_config()
+        return json_response({"ok": True})
 
     async def _api_push_group_add(self, request):
         p = self.plugin
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         gid = str(data.get("group_id", ""))
         if gid and gid not in (getattr(p, "rank_push_groups", []) or []):
             getattr(p, "rank_push_groups").append(gid)
         p._save_rank_push_groups()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
     async def _api_push_group_remove(self, request):
         p = self.plugin
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         gid = str(data.get("group_id", ""))
         groups = getattr(p, "rank_push_groups", []) or []
         if gid in groups:
             groups.remove(gid)
         p._save_rank_push_groups()
-        return web.json_response({"ok": True})
+        return json_response({"ok": True})
 
-    async def _api_push_all_toggle(self, request):
+    async def _api_push_rank_scope(self, request):
         p = self.plugin
-        p.rank_push_all = not getattr(p, "rank_push_all", False)
+        try:
+            data = await request.json()
+        except Exception:
+            return json_response({"error": "invalid JSON"}, status_code=400)
+        scope = str(data.get("scope", "")).strip().lower()
+        if scope not in {"group", "global"}:
+            return json_response(
+                {"error": "scope must be group or global"},
+                status_code=400,
+            )
+        p.rank_push_all = scope == "global"
         p._save_rank_push_groups()
-        return web.json_response({"ok": True, "rank_push_all": p.rank_push_all})
+        return json_response({
+            "ok": True,
+            "rank_push_all": p.rank_push_all,
+            "scope": scope,
+        })
 
     # ────── Settings ──────
 
@@ -935,15 +972,15 @@ class WebAdminServer:
         for key in ("steam_api_key", "sgdb_api_key"):
             if config.get(key):
                 config[key] = "******" + config[key][-4:] if len(config[key]) > 4 else "******"
-        config["web_port"] = getattr(p, "_web_port", 6195)
-        return web.json_response(config)
+        config.pop("web_port", None)
+        return json_response(config)
 
     async def _api_settings_update(self, request):
         p = self.plugin
         try:
             data = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return json_response({"error": "invalid JSON"}, status_code=400)
         skip_keys = {"steam_api_key", "sgdb_api_key"}
         for key, value in data.items():
             if key in skip_keys:
@@ -973,10 +1010,9 @@ class WebAdminServer:
                 p.config[key] = str(value)
                 if p.config.get("enable_proxy"):
                     p.proxy = str(value)
-            elif key == "web_port":
-                p._web_port = int(value)
-                p.config[key] = int(value)
-        return web.json_response({"ok": True})
+        if hasattr(p.config, "save_config"):
+            p.config.save_config()
+        return json_response({"ok": True})
 
     # ────── Search ──────
 
@@ -992,7 +1028,7 @@ class WebAdminServer:
                 if q and q not in name.lower() and q not in sid:
                     continue
                 results.append({"sid": sid, "name": name, "group_id": gid})
-        return web.json_response({"results": results[:50]})
+        return json_response({"results": results[:50]})
 
     # ────── Player Avatar / Info ──────
 
@@ -1008,7 +1044,7 @@ class WebAdminServer:
                 avatar_url = state.get("avatarfull") or state.get("avatar") or ""
                 if avatar_url:
                     break
-        return web.json_response({"steamid": steamid, "avatar_url": avatar_url})
+        return json_response({"steamid": steamid, "avatar_url": avatar_url})
 
     async def _api_player_info(self, request):
         """获取玩家详细信息卡片数据"""
@@ -1064,7 +1100,7 @@ class WebAdminServer:
         sid_num = int(steamid) if steamid.isdigit() else None
         profile_url = f"https://steamcommunity.com/profiles/{sid_num}" if sid_num else ""
 
-        return web.json_response({
+        return json_response({
             "steamid": steamid,
             "name": name,
             "current_game": current_game,
@@ -1080,15 +1116,22 @@ class WebAdminServer:
         p = self.plugin
         gameid = request.match_info.get("gameid", "")
         if not gameid:
-            return web.json_response({"error": "no gameid"}, status=400)
+            return json_response({"error": "no gameid"}, status_code=400)
         try:
             if hasattr(p, "get_game_cover_url"):
                 cover_path = await p.get_game_cover_url(gameid)
                 if cover_path and os.path.exists(str(cover_path)):
-                    return web.FileResponse(str(cover_path))
-        except Exception:
-            pass
-        return web.json_response({"gameid": gameid, "cover_path": ""})
+                    path = str(cover_path)
+                    mime = mimetypes.guess_type(path)[0] or "image/jpeg"
+                    with open(path, "rb") as cover_file:
+                        encoded = base64.b64encode(cover_file.read()).decode("ascii")
+                    return json_response({
+                        "gameid": gameid,
+                        "data_url": f"data:{mime};base64,{encoded}",
+                    })
+        except Exception as e:
+            logger.warning(f"[WebAdmin] 读取游戏封面失败 gameid={gameid}: {e}")
+        return json_response({"gameid": gameid, "data_url": ""})
 
     # ────── Test APIs ──────
 
@@ -1160,7 +1203,7 @@ class WebAdminServer:
                 log.append(f"[SGDB API] 异常: {e}")
             log.append("[竖版封面] 开始测试...")
             try:
-                from ..game_start_render import get_sgdb_vertical_cover
+                from .game_start_render import get_sgdb_vertical_cover
                 sgdb_url = await get_sgdb_vertical_cover("NEKOPARA Vol. 0", sgdb_api_key=sgdb_k, appid="385800", proxy=proxy)
                 if sgdb_url:
                     results["sgdb_cover"] = "ok"
@@ -1177,7 +1220,7 @@ class WebAdminServer:
             logger.info(f"[WebAdmin] 测试: {line}")
             print(f"  [测试] {line}")
 
-        return web.json_response(results)
+        return json_response(results)
 
     async def _api_test_cover(self, request):
         """测试游戏封面获取"""
@@ -1187,25 +1230,29 @@ class WebAdminServer:
             try:
                 path = await p.get_game_cover_url(test_gid)
                 if path and os.path.exists(str(path)):
-                    return web.json_response({"cover": "ok", "path": str(path), "size_kb": round(os.path.getsize(str(path))/1024, 1)})
-                return web.json_response({"cover": "not_found", "path": str(path)})
+                    return json_response({
+                        "cover": "ok",
+                        "path": str(path),
+                        "size_kb": round(os.path.getsize(str(path)) / 1024, 1),
+                    })
+                return json_response({"cover": "not_found", "path": str(path)})
             except Exception as e:
-                return web.json_response({"cover": "error", "message": str(e)})
-        return web.json_response({"cover": "method_not_found"})
+                return json_response({"cover": "error", "message": str(e)})
+        return json_response({"cover": "method_not_found"})
 
     async def _api_test_steamid(self, request):
         """测试 SteamID 查询"""
         p = self.plugin
         steamid = request.match_info.get("steamid", "")
         if not steamid.isdigit():
-            return web.json_response({"error": "invalid steamid"}, status=400)
+            return json_response({"error": "invalid steamid"}, status_code=400)
         import httpx
         try:
             # 直接从 last_states 读取缓存
             for gid_states in (getattr(p, "group_last_states", {}) or {}).values():
                 state = gid_states.get(steamid, {})
                 if state:
-                    return web.json_response({
+                    return json_response({
                         "from_cache": True,
                         "name": state.get("name"),
                         "game": state.get("gameextrainfo"),
@@ -1215,15 +1262,15 @@ class WebAdminServer:
             # 未缓存则调用 Steam API
             ak = getattr(p, "API_KEY", "")
             if not ak:
-                return web.json_response({"error": "no api key"})
+                return json_response({"error": "no api key"})
             url = f"{p.STEAM_API_BASE}/ISteamUser/GetPlayerSummaries/v2/?key={ak}&steamids={steamid}"
             async with httpx.AsyncClient(timeout=10, proxy=getattr(p, "proxy", None)) as c:
                 r = await c.get(url)
                 if r.status_code == 200:
                     players = r.json().get("response", {}).get("players", [])
                     if players:
-                        return web.json_response({"from_api": True, "player": players[0]})
-                    return web.json_response({"error": "player_not_found"})
-                return web.json_response({"error": f"http_{r.status_code}"})
+                        return json_response({"from_api": True, "player": players[0]})
+                    return json_response({"error": "player_not_found"})
+                return json_response({"error": f"http_{r.status_code}"})
         except Exception as e:
-            return web.json_response({"error": str(e)})
+            return json_response({"error": str(e)})


### PR DESCRIPTION
## Summary

- Migrate the standalone aiohttp admin site into AstrBot Plugin Pages.
- Register the existing management APIs through `context.register_web_api` and call them through the authenticated Page bridge.
- Move frontend assets to `pages/steam-monitor`, add Page metadata/i18n, theme support, in-page dialogs, and bridge-compatible image loading.
- Remove the standalone WebUI port setting and lifecycle task.
- Generate the scheduled daily ranking separately for every target group by default.
- Keep the existing shared global ranking only as an explicit scope option.

## Why

The scheduled push previously passed `group_id=None` in both branches of its scope condition, so every target group received the same ranking containing players from all monitored groups. The standalone management site also required an extra listening port instead of using AstrBot's built-in authenticated WebUI.

## Behavior

- Normal mode: each receiving group is ranked from only that group's configured Steam IDs.
- Global mode: all selected receiving groups share one global ranking, preserving the existing opt-in behavior.
- An empty ranking, render failure, missing session, or send failure for one group no longer prevents the remaining groups from being processed.
- Temporary ranking images are removed after delivery.

## Compatibility

- Requires AstrBot `>=4.24.2`, where Plugin Pages are available.
- `aiohttp` remains a dependency because the achievement monitor still uses it.
- Existing `rank_push_groups.json` data remains compatible.

## Validation

- `node --check pages/steam-monitor/app.js`
- `python -m unittest discover -s tests -v`
- Parsed all Python files with `ast.parse`
- Parsed `_conf_schema.json` and both Page i18n JSON files
- `git diff --cached --check`
