### PR TITLE
fix: 修复初始化时跨群同一 SteamID 状态不一致

### DIFF
--- a/achievement_monitor.py
+++ b/achievement_monitor.py
@@ -66,7 +66,7 @@ class AchievementMonitor:
         # 黑名单机制
         if hasattr(self, 'achievement_blacklist') and str(appid) in self.achievement_blacklist:
             return None
-        url = "https://api.steampowered.com/ISteamUserStats/GetPlayerAchievements/v1/"
+        url = f"{self.steam_api_base}/ISteamUserStats/GetPlayerAchievements/v1/"
         lang_list = ["schinese", "english", "en"]
         all_failed = True
         for lang in lang_list:
@@ -122,10 +122,10 @@ class AchievementMonitor:
         if cache_key in self.details_cache:
             return self.details_cache[cache_key]
         lang_list = [lang, "schinese", "english", "en"]
-        url_stats = f"https://api.steampowered.com/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/?gameid={appid}"
+        url_stats = f"{self.steam_api_base}/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/?gameid={appid}"
         details = {}
         for try_lang in lang_list:
-            url = f"https://api.steampowered.com/ISteamUserStats/GetSchemaForGame/v2/?appid={appid}&key={api_key}&l={try_lang}"
+            url = f"{self.steam_api_base}/ISteamUserStats/GetSchemaForGame/v2/?appid={appid}&key={api_key}&l={try_lang}"
             try:
                 async with httpx.AsyncClient(timeout=15, proxy=self.proxy) as client:
                     # 成就元数据
@@ -143,7 +143,10 @@ class AchievementMonitor:
                                 "appid": appid,
                                 "l": lang2
                             }
-                            resp2 = await client.get("https://api.steampowered.com/ISteamUserStats/GetPlayerAchievements/v1/", params=params)
+                            resp2 = await client.get(
+                                f"{self.steam_api_base}/ISteamUserStats/GetPlayerAchievements/v1/",
+                                params=params,
+                            )
                             if resp2.status_code == 200:
                                 try:
                                     data = resp2.json()

--- a/game_end_render.py
+++ b/game_end_render.py
@@ -6,6 +6,7 @@ import asyncio
 import httpx
 from PIL import Image, ImageDraw, ImageFont
 from .game_start_render import get_avatar_frame_url, get_avatar_frame_path, _cache_config, get_horizontal_cover_path
+from .steam_cover import get_steam_library_cover_url
 
 # 更深的蓝紫色到黑色渐变
 BG_COLOR_TOP = (24, 18, 48)   # 顶部深蓝紫
@@ -106,29 +107,53 @@ def render_gradient_bg(img_w, img_h, color_top, color_bottom):
     return base
 
 # get_cover_path 改为 async def 并 await get_sgdb_vertical_cover
-async def get_cover_path(data_dir, gameid, game_name, force_update=False, sgdb_api_key=None, sgdb_game_name=None, appid=None, proxy=None):
+async def get_cover_path(data_dir, gameid, game_name, force_update=False, sgdb_api_key=None, sgdb_game_name=None, appid=None, proxy=None, api_key=None):
     from PIL import Image as PILImage
     import httpx
     cover_dir = os.path.join(data_dir, "covers_v")
     os.makedirs(cover_dir, exist_ok=True)
-    path = os.path.join(cover_dir, f"{gameid}.jpg")
+    steam_path = os.path.join(cover_dir, f"{gameid}_library_capsule_2x.jpg")
+    fallback_path = os.path.join(cover_dir, f"{gameid}.jpg")
     cover_refresh = _cache_config.get("cover_vertical", 0)
-    if cover_refresh == 0 and os.path.exists(path):
-        return path
-    elif cover_refresh > 0 and os.path.exists(path):
-        if time.time() - os.path.getmtime(path) < cover_refresh:
-            return path
-    # 只尝试 SGDB 竖版封面
-    url = await get_sgdb_vertical_cover(game_name, sgdb_api_key, sgdb_game_name=sgdb_game_name, appid=appid, proxy=proxy)
+
+    def is_cache_valid(path):
+        if force_update or not os.path.exists(path):
+            return False
+        return cover_refresh == 0 or time.time() - os.path.getmtime(path) < cover_refresh
+
+    if api_key and is_cache_valid(steam_path):
+        return steam_path
+
+    steam_appid = appid or gameid
+    if api_key:
+        url = await get_steam_library_cover_url(steam_appid, api_key, proxy=proxy)
+        if url:
+            try:
+                async with httpx.AsyncClient(timeout=10, proxy=proxy) as client:
+                    resp = await client.get(url)
+                if resp.status_code == 200:
+                    with open(steam_path, "wb") as f:
+                        f.write(resp.content)
+                    print(f"[get_cover_path] Steam library_capsule_2x 下载成功: {gameid} -> {steam_path}")
+                    return steam_path
+            except Exception as e:
+                print(f"[get_cover_path] Steam library_capsule_2x 下载异常: {e} url={url}")
+
+    if is_cache_valid(fallback_path):
+        return fallback_path
+
+    url = await get_sgdb_vertical_cover(game_name, sgdb_api_key, sgdb_game_name=sgdb_game_name, appid=steam_appid, proxy=proxy)
     if url:
         try:
-            resp = httpx.get(url, timeout=10, proxy=proxy)
+            async with httpx.AsyncClient(timeout=10, proxy=proxy) as client:
+                resp = await client.get(url)
             if resp.status_code == 200:
-                with open(path, "wb") as f:
+                with open(fallback_path, "wb") as f:
                     f.write(resp.content)
-                return path
+                print(f"[get_cover_path] SteamGridDB 下载成功: {gameid} -> {fallback_path}")
+                return fallback_path
         except Exception as e:
-            print(f"[get_cover_path] SGDB下载异常: {e} url={url}")
+            print(f"[get_cover_path] SteamGridDB 下载异常: {e} url={url}")
     # 新增：SGDB未收录或下载失败时，使用missingcover.jpg
     print(f"[get_cover_path] SGDB未收录或下载失败: {gameid} {game_name}，使用默认封面")
     missing_cover = os.path.join(os.path.dirname(__file__), "missingcover.jpg")
@@ -396,9 +421,9 @@ def render_game_end_image(player_name, avatar_path, game_name, cover_path, end_t
     return img.convert("RGB")
 
 # render_game_end 里 await get_cover_path
-async def render_game_end(data_dir, steamid, player_name, avatar_url, gameid, game_name, end_time_str, tip_text, duration_h, sgdb_api_key=None, font_path=None, sgdb_game_name=None, appid=None, proxy=None):
+async def render_game_end(data_dir, steamid, player_name, avatar_url, gameid, game_name, end_time_str, tip_text, duration_h, sgdb_api_key=None, font_path=None, sgdb_game_name=None, appid=None, proxy=None, api_key=None):
     avatar_path = get_avatar_path(data_dir, steamid, avatar_url, proxy=proxy)
-    cover_path = await get_cover_path(data_dir, gameid, game_name, sgdb_api_key=sgdb_api_key, sgdb_game_name=sgdb_game_name, appid=appid, proxy=proxy)
+    cover_path = await get_cover_path(data_dir, gameid, game_name, sgdb_api_key=sgdb_api_key, sgdb_game_name=sgdb_game_name, appid=appid, proxy=proxy, api_key=api_key)
     # 获取横版封面（竖版缺失时叠加用）
     horizontal_cover_path = get_horizontal_cover_path(data_dir, gameid, appid=appid, proxy=proxy)
     avatar_frame_path = await get_avatar_frame_path(data_dir, steamid, proxy=proxy)

--- a/game_start_render.py
+++ b/game_start_render.py
@@ -4,6 +4,7 @@ import time
 import httpx
 from PIL import Image, ImageDraw, ImageFont
 import random
+from .steam_cover import get_steam_library_cover_url
 
 BG_COLOR_TOP = (49, 80, 66)
 BG_COLOR_BOTTOM = (28, 35, 44)
@@ -198,30 +199,54 @@ async def get_sgdb_vertical_cover(game_name, sgdb_api_key=None, sgdb_game_name=N
             print(f"[get_sgdb_vertical_cover] SGDB API异常: {e}")
             return None
 
-async def get_cover_path(data_dir, gameid, game_name, force_update=False, sgdb_api_key=None, sgdb_game_name=None, appid=None, proxy=None):
+async def get_cover_path(data_dir, gameid, game_name, force_update=False, sgdb_api_key=None, sgdb_game_name=None, appid=None, proxy=None, api_key=None):
     from PIL import Image as PILImage
     import httpx
     cover_dir = os.path.join(data_dir, "covers_v")
     os.makedirs(cover_dir, exist_ok=True)
-    path = os.path.join(cover_dir, f"{gameid}.jpg")
+    steam_path = os.path.join(cover_dir, f"{gameid}_library_capsule_2x.jpg")
+    fallback_path = os.path.join(cover_dir, f"{gameid}.jpg")
     # 只在本地不存在时才云端获取
     cover_refresh = _cache_config.get("cover_vertical", 0)
-    if cover_refresh == 0 and os.path.exists(path):
-        return path
-    elif cover_refresh > 0 and os.path.exists(path):
-        if time.time() - os.path.getmtime(path) < cover_refresh:
-            return path
-    # 只尝试 SGDB 竖版封面
-    url = await get_sgdb_vertical_cover(game_name, sgdb_api_key, sgdb_game_name=sgdb_game_name, appid=appid, proxy=proxy)
+
+    def is_cache_valid(path):
+        if force_update or not os.path.exists(path):
+            return False
+        return cover_refresh == 0 or time.time() - os.path.getmtime(path) < cover_refresh
+
+    if api_key and is_cache_valid(steam_path):
+        return steam_path
+
+    steam_appid = appid or gameid
+    if api_key:
+        url = await get_steam_library_cover_url(steam_appid, api_key, proxy=proxy)
+        if url:
+            try:
+                async with httpx.AsyncClient(timeout=10, proxy=proxy) as client:
+                    resp = await client.get(url)
+                if resp.status_code == 200:
+                    with open(steam_path, "wb") as f:
+                        f.write(resp.content)
+                    print(f"[get_cover_path] Steam library_capsule_2x 下载成功: {gameid} -> {steam_path}")
+                    return steam_path
+            except Exception as e:
+                print(f"[get_cover_path] Steam library_capsule_2x 下载异常: {e} url={url}")
+
+    if is_cache_valid(fallback_path):
+        return fallback_path
+
+    url = await get_sgdb_vertical_cover(game_name, sgdb_api_key, sgdb_game_name=sgdb_game_name, appid=steam_appid, proxy=proxy)
     if url:
         try:
-            resp = httpx.get(url, timeout=10, proxy=proxy)
+            async with httpx.AsyncClient(timeout=10, proxy=proxy) as client:
+                resp = await client.get(url)
             if resp.status_code == 200:
-                with open(path, "wb") as f:
+                with open(fallback_path, "wb") as f:
                     f.write(resp.content)
-                return path
+                print(f"[get_cover_path] SteamGridDB 下载成功: {gameid} -> {fallback_path}")
+                return fallback_path
         except Exception as e:
-            print(f"[get_cover_path] SGDB下载异常: {e} url={url}")
+            print(f"[get_cover_path] SteamGridDB 下载异常: {e} url={url}")
     # 新增：SGDB未收录或下载失败时，使用missingcover.jpg
     print(f"[get_cover_path] SGDB未收录或下载失败: {gameid} {game_name}，使用默认封面")
     missing_cover = os.path.join(os.path.dirname(__file__), "missingcover.jpg")
@@ -535,7 +560,7 @@ def render_game_start_image(player_name, avatar_path, game_name, cover_path, pla
 async def render_game_start(data_dir, steamid, player_name, avatar_url, gameid, game_name, api_key=None, superpower=None, online_count=None, sgdb_api_key=None, font_path=None, sgdb_game_name=None, appid=None, proxy=None, version=None):
     print(f"[render_game_start] superpower参数: {superpower}")
     avatar_path = get_avatar_path(data_dir, steamid, avatar_url, proxy=proxy)
-    cover_path = await get_cover_path(data_dir, gameid, game_name, sgdb_api_key=sgdb_api_key, sgdb_game_name=sgdb_game_name, appid=appid, proxy=proxy)
+    cover_path = await get_cover_path(data_dir, gameid, game_name, sgdb_api_key=sgdb_api_key, sgdb_game_name=sgdb_game_name, appid=appid, proxy=proxy, api_key=api_key)
     # 获取横版封面（竖版缺失时叠加用）
     horizontal_cover_path = get_horizontal_cover_path(data_dir, gameid, appid=appid, proxy=proxy)
     playtime_hours = None

--- a/main.py
+++ b/main.py
@@ -586,14 +586,23 @@ class SteamStatusMonitorV3(Star):
         '''插件启动后10秒内进行一次全员初始化轮询，设置每个SteamID的next_poll_time，并输出一次初始日志'''
         await asyncio.sleep(10)
         all_logs = []
-        seen_sids = set()  # 防止同一sid在多个群中被重复推送
+        # Steam 状态查询按 SID 去重，但状态基线必须按群分别建立。
+        unique_sids = list(dict.fromkeys(
+            sid
+            for steam_ids in self.group_steam_ids.values()
+            for sid in steam_ids
+        ))
+        status_map = await self.fetch_player_statuses_batch(unique_sids)
         for group_id in self.group_steam_ids:
             steam_ids = self.group_steam_ids[group_id]
             group_lines = []
             for sid in steam_ids:
-                if sid in seen_sids: continue
-                seen_sids.add(sid)
-                msg = await self.check_status_change(group_id, single_sid=sid, skip_push=True)
+                msg = await self.check_status_change(
+                    group_id,
+                    single_sid=sid,
+                    status_override=status_map.get(sid),
+                    skip_push=True,
+                )
                 if msg:
                     group_lines.append(msg)
             if group_lines:

--- a/main.py
+++ b/main.py
@@ -2049,7 +2049,7 @@ class SteamStatusMonitorV3(Star):
             img_bytes = await render_game_end(
                 self.data_dir, steamid, player_name, avatar_url, gameid, zh_game_name,
                 end_time_str, tip_text, duration_h, sgdb_api_key=self.SGDB_API_KEY, font_path=font_path, sgdb_game_name=en_game_name, appid=gameid
-            , proxy=self.proxy)
+            , proxy=self.proxy, api_key=self.API_KEY)
             msg = f"👋 {player_name} 不玩 {zh_game_name} 了\n游玩时间 {duration_h:.1f}小时"
             import tempfile
             with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
@@ -2297,7 +2297,7 @@ class SteamStatusMonitorV3(Star):
                     end_time_str, tip_text, duration_h,
                     sgdb_api_key=self.SGDB_API_KEY, font_path=font_path,
                     sgdb_game_name=en_game_name, appid=noti.get("gameid"),
-                    proxy=self.proxy)
+                    proxy=self.proxy, api_key=self.API_KEY)
             import tempfile
             with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
                 tmp.write(img_bytes)

--- a/steam_cover.py
+++ b/steam_cover.py
@@ -1,0 +1,50 @@
+import json
+from urllib.parse import quote
+
+import httpx
+
+
+STEAM_STORE_BROWSE_URL = "https://api.steampowered.com/IStoreBrowseService/GetItems/v1/"
+STEAM_STORE_ASSET_BASE = "https://shared.fastly.steamstatic.com/store_item_assets/steam/apps"
+
+
+async def get_steam_library_cover_url(appid, api_key, proxy=None):
+    """Return Steam's high-resolution vertical library cover URL for an app."""
+    if not appid or not api_key:
+        return None
+
+    input_json = {
+        "ids": [{"appid": str(appid)}],
+        "context": {"language": "schinese", "country_code": "CN"},
+        "data_request": {"include_assets": True},
+    }
+    params = {
+        "key": api_key,
+        "input_json": json.dumps(input_json, ensure_ascii=False, separators=(",", ":")),
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10, proxy=proxy) as client:
+            response = await client.get(STEAM_STORE_BROWSE_URL, params=params)
+        if response.status_code != 200:
+            print(
+                "[get_steam_library_cover_url] Steam 接口请求失败: "
+                f"appid={appid}, 状态码={response.status_code}"
+            )
+            return None
+
+        store_items = response.json().get("response", {}).get("store_items", [])
+        item = next(
+            (entry for entry in store_items if str(entry.get("appid", entry.get("id"))) == str(appid)),
+            None,
+        )
+        assets_path = (item or {}).get("assets", {}).get("library_capsule_2x")
+        if not assets_path:
+            print(f"[get_steam_library_cover_url] 未获取到 library_capsule_2x 字段: appid={appid}")
+            return None
+        return f"{STEAM_STORE_ASSET_BASE}/{appid}/{quote(assets_path, safe='/')}"
+    except Exception as e:
+        print(
+            "[get_steam_library_cover_url] Steam 接口异常: "
+            f"appid={appid}, 异常类型={type(e).__name__}"
+        )
+        return None


### PR DESCRIPTION
### 摘要
- 对所有群的 SteamID 去重后批量获取状态，同时按群分别建立状态基线，避免跨群同一 SteamID 被跳过。
- 通过 `status_override` 复用批量查询结果，减少初始化阶段的重复请求。
- 成就查询统一使用可配置的 `steam_api_base` 构建 Steam API 地址。
- 新增 Steam 官方高清竖版库封面获取与独立缓存，并在获取失败时回退到 SteamGridDB 或默认封面。
- 封面下载改用异步 HTTP 请求，并将 Steam API Key 传递到开始及结束通知的渲染流程。