### PR TITLE
fix(通知): 避免主群与联动群重复投递

### DIFF
--- a/src/plugin/steam_status_monitor.py
+++ b/src/plugin/steam_status_monitor.py
@@ -1757,13 +1757,24 @@ class SteamStatusMonitorV3(PersistenceMixin, SteamClientMixin, Star):
             logger.error(f"[排行榜] 记录游玩时长异常: {e}")
 
     def _get_notify_sessions(self, group_id, sid):
-        """获取需要通知的所有 session（主群 + 联动群），去重返回"""
+        """获取本次状态检测需要通知的 session，避免主群与联动群交叉重复投递。"""
         sessions = []
-        ns = getattr(self, 'notify_sessions', {}).get(group_id, None)
-        if ns and ns not in sessions:
-            sessions.append(ns)
+        notify_sessions = getattr(self, 'notify_sessions', {})
+        primary_session = notify_sessions.get(group_id)
+        if primary_session:
+            sessions.append(primary_session)
+
+        # 同一玩家可能同时属于多个主群。每个主群都会独立执行状态检测，因此这里
+        # 只补充该玩家未被直接监控的联动群；否则 A 主群发送 A+B、B 主群再发送
+        # B+A，会让两个群各收到两次完全相同的通知。
+        monitored_groups = {
+            gid for gid, steam_ids in getattr(self, 'group_steam_ids', {}).items()
+            if sid in steam_ids
+        }
         for push_gid in self.push_groups.get(sid, []):
-            push_session = getattr(self, 'notify_sessions', {}).get(push_gid, None)
+            if push_gid != group_id and push_gid in monitored_groups:
+                continue
+            push_session = notify_sessions.get(push_gid)
             if push_session and push_session not in sessions:
                 sessions.append(push_session)
         return sessions

--- a/tests/unit/test_notification_routing.py
+++ b/tests/unit/test_notification_routing.py
@@ -30,7 +30,7 @@ class NotificationRoutingTests(unittest.TestCase):
         self.get_notify_sessions = load_get_notify_sessions()
 
     def test_cross_linked_primary_groups_are_not_sent_twice(self):
-        sid = "76561199147891480"
+        sid = "test-steam-id"
         plugin = type("Plugin", (), {})()
         plugin.notify_sessions = {"group-a": "session-a", "group-b": "session-b"}
         plugin.group_steam_ids = {"group-a": [sid], "group-b": [sid]}
@@ -44,7 +44,7 @@ class NotificationRoutingTests(unittest.TestCase):
         )
 
     def test_linked_group_without_direct_monitoring_still_receives_notification(self):
-        sid = "76561199147891480"
+        sid = "test-steam-id"
         plugin = type("Plugin", (), {})()
         plugin.notify_sessions = {"group-a": "session-a", "group-b": "session-b"}
         plugin.group_steam_ids = {"group-a": [sid], "group-b": []}

--- a/tests/unit/test_notification_routing.py
+++ b/tests/unit/test_notification_routing.py
@@ -1,0 +1,60 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+IMPLEMENTATION_PATH = PROJECT_ROOT / "src/plugin/steam_status_monitor.py"
+
+
+def load_get_notify_sessions():
+    tree = ast.parse(IMPLEMENTATION_PATH.read_text(encoding="utf-8"))
+    plugin_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "SteamStatusMonitorV3"
+    )
+    method = next(
+        node
+        for node in plugin_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_get_notify_sessions"
+    )
+    module = ast.Module(body=[method], type_ignores=[])
+    namespace = {}
+    exec(compile(ast.fix_missing_locations(module), str(IMPLEMENTATION_PATH), "exec"), namespace)
+    return namespace["_get_notify_sessions"]
+
+
+class NotificationRoutingTests(unittest.TestCase):
+    def setUp(self):
+        self.get_notify_sessions = load_get_notify_sessions()
+
+    def test_cross_linked_primary_groups_are_not_sent_twice(self):
+        sid = "76561199147891480"
+        plugin = type("Plugin", (), {})()
+        plugin.notify_sessions = {"group-a": "session-a", "group-b": "session-b"}
+        plugin.group_steam_ids = {"group-a": [sid], "group-b": [sid]}
+        plugin.push_groups = {sid: ["group-a", "group-b"]}
+
+        self.assertEqual(
+            ["session-a"], self.get_notify_sessions(plugin, "group-a", sid)
+        )
+        self.assertEqual(
+            ["session-b"], self.get_notify_sessions(plugin, "group-b", sid)
+        )
+
+    def test_linked_group_without_direct_monitoring_still_receives_notification(self):
+        sid = "76561199147891480"
+        plugin = type("Plugin", (), {})()
+        plugin.notify_sessions = {"group-a": "session-a", "group-b": "session-b"}
+        plugin.group_steam_ids = {"group-a": [sid], "group-b": []}
+        plugin.push_groups = {sid: ["group-b"]}
+
+        self.assertEqual(
+            ["session-a", "session-b"],
+            self.get_notify_sessions(plugin, "group-a", sid),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
识别同一 Steam 玩家已被直接监控的群，仅向未直接监控该玩家的联动群补充通知，并增加交叉主群及正常联动场景的回归测试。

原路由会在玩家同时属于多个主群且配置交叉联动时重复扇出同一事件，导致各群收到两次相同消息；限制联动收件人可消除重复且保留正常跨群推送。