### PR TITLE
feat(fonts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 | `proxy_url` | 代理链接（如 `http://127.0.0.1:7890`） | 空 |
 | `font_download_enabled` | 启动后自动下载 CJK 字体包 | true |
 | `font_pack_url` | 自定义字体包 URL（须 https，仍按清单校验） | 空 |
-| `font_download_timeout_sec` | 字体包下载超时（秒） | 120 |
+| `font_download_timeout_sec` | 字体包下载超时（秒） | 600 |
 
 > 带「修改后重启AstrBot生效」标注的配置项需重启后生效。
 
@@ -84,7 +84,7 @@
 - Steam 查询出现 `ConnectTimeout` / `ReadTimeout` 时，结束卡仍会按时发出，不会等到下次开局才补发。网络不稳定时建议开启代理。
 - 监控人数较多时，建议适当调高 `max_group_size` 并保持智能轮询，以兼顾时效与 Steam 限流。
 - Steam 摘要同一时刻只有一个 `gameid`，插件不能识别「同时玩多款游戏」，A→B 会视为切换并立即结算 A。
-- 商店安装后首次启动会在后台下载 CJK 字体（约 39MB）。可用 `/steam fonts` 查看状态，`/steam fonts download` 立即下载并显示进度，`/steam fonts clean` 清理缓存。开发克隆若 `assets/fonts` 已有字体则跳过下载。
+- 商店安装后首次启动会在后台下载 CJK 字体（约 39MB）。默认先走国内 GitHub 镜像（`gh-proxy.com` / `ghproxy.net` / `github.akams.cn`），失败再回退官方 Release；单个源超时默认 10 分钟。可用 `/steam fonts` 查看状态，`/steam fonts download` 立即下载并显示进度，`/steam fonts clean` 清理缓存。填写 `font_pack_url` 则只用自定义地址。开发克隆若 `assets/fonts` 已有字体则跳过下载。
 
 ## 演示截图
 ![开始游戏示例](https://raw.githubusercontent.com/Maoer233/astrbot_plugin_steam_status_monitor/main/assets/images/str.png)

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -122,20 +122,20 @@
   "font_download_enabled": {
     "description": "启动后自动下载 CJK 字体包",
     "type": "bool",
-    "hint": "商店包不含字体。开启后插件会在后台从 GitHub Release 下载 fonts-bundle；关闭则仅使用本地已缓存或系统字体（修改后重启AstrBot生效）",
+    "hint": "商店包不含字体。开启后插件会在后台优先经国内镜像下载 fonts-bundle，失败再回退 GitHub；关闭则仅使用本地已缓存或系统字体（修改后重启AstrBot生效）",
     "default": true
   },
   "font_pack_url": {
     "description": "自定义字体包下载地址",
     "type": "string",
-    "hint": "留空使用官方 fonts-bundle。填写后仍按清单 SHA256 校验，且必须是 https（修改后重启AstrBot生效）",
+    "hint": "留空则按 GitHub Release 走国内镜像并回退官方地址。填写后只使用该 https 地址，仍按清单 SHA256 校验（修改后重启AstrBot生效）",
     "default": ""
   },
   "font_download_timeout_sec": {
     "description": "字体包下载超时（秒）",
     "type": "int",
-    "hint": "整包下载超时时间，默认 120 秒（修改后重启AstrBot生效）",
-    "default": 120
+    "hint": "单个下载源的读取超时，默认 600 秒（10 分钟）。连接超时固定约 15 秒以便快速换源（修改后重启AstrBot生效）",
+    "default": 600
   },
   "steam_api_base": {
     "description": "Steam Web API 代理地址",

--- a/src/infrastructure/fonts/pack_service.py
+++ b/src/infrastructure/fonts/pack_service.py
@@ -41,6 +41,13 @@ _MAX_NOT_FOUND_ATTEMPTS = 5
 _MAX_HASH_FAILURES = 3
 _PROGRESS_CHUNK = 2 * 1024 * 1024
 _PROGRESS_INTERVAL = 2.0
+_DEFAULT_TIMEOUT_SEC = 600
+_CONNECT_TIMEOUT_SEC = 15.0
+_GITHUB_MIRROR_PREFIXES = (
+    "https://gh-proxy.com/",
+    "https://ghproxy.net/",
+    "https://github.akams.cn/",
+)
 
 ProgressCallback = Callable[[dict], Awaitable[None] | None]
 
@@ -58,6 +65,35 @@ def _sha256_file(path: str) -> str:
 
 def _is_https(url: str) -> bool:
     return urlsplit(url).scheme.lower() == "https"
+
+
+def _is_github_release_url(url: str) -> bool:
+    parts = urlsplit(url)
+    if parts.scheme.lower() != "https":
+        return False
+    host = parts.netloc.lower()
+    if host != "github.com" and not host.endswith(".github.com"):
+        return False
+    return "/releases/download/" in parts.path
+
+
+def candidate_download_urls(url: str, *, use_mirrors: bool = True) -> list[str]:
+    """GitHub Release 先走国内镜像，官方地址兜底。自定义非 GitHub 源不包装。"""
+    url = (url or "").strip()
+    if not url:
+        return []
+    if not use_mirrors or not _is_github_release_url(url):
+        return [url]
+    seen: set[str] = set()
+    candidates: list[str] = []
+    for prefix in _GITHUB_MIRROR_PREFIXES:
+        mirrored = prefix.rstrip("/") + "/" + url
+        if mirrored not in seen:
+            seen.add(mirrored)
+            candidates.append(mirrored)
+    if url not in seen:
+        candidates.append(url)
+    return candidates
 
 
 def _safe_url(url: str) -> str:
@@ -166,7 +202,7 @@ class FontPackService:
         proxy: str | None = None,
         enabled: bool = True,
         pack_url: str = "",
-        timeout_sec: int = 120,
+        timeout_sec: int = _DEFAULT_TIMEOUT_SEC,
         bundled_dir: str | None = None,
         manifest_path: str | None = None,
     ):
@@ -177,7 +213,7 @@ class FontPackService:
         self.proxy = proxy
         self.enabled = enabled
         self.pack_url_override = (pack_url or "").strip()
-        self.timeout_sec = max(int(timeout_sec or 120), 10)
+        self.timeout_sec = max(int(timeout_sec or _DEFAULT_TIMEOUT_SEC), 10)
         self.bundled_dir = bundled_dir or str(FONTS_DIR)
         self.manifest_path = manifest_path or str(FONT_MANIFEST_PATH)
         self.status = STATUS_MISSING
@@ -335,8 +371,11 @@ class FontPackService:
             if self.pack_url_override and not _is_https(self.pack_url_override):
                 raise FontPackError("自定义字体包 URL 必须是 https", retryable=False, kind="config")
             self._check_disk_space(manifest)
-            logger.info("[Font] 开始下载字体包 %s", _safe_url(url))
-            await self._download_and_install(manifest, url)
+            await self._download_and_install(
+                manifest,
+                url,
+                use_mirrors=not bool(self.pack_url_override) and not bool(self.proxy),
+            )
             self.status = STATUS_READY
             self.error = ""
             self._retry_index = 0
@@ -442,34 +481,75 @@ class FontPackService:
                 kind="disk",
             )
 
-    async def _download_and_install(self, manifest: FontManifest, url: str) -> None:
+    async def _download_and_install(
+        self,
+        manifest: FontManifest,
+        url: str,
+        *,
+        use_mirrors: bool = True,
+    ) -> None:
         self.status = STATUS_DOWNLOADING
-        self.downloaded = 0
-        self.total = 0
-        self._speed_samples = [(time.monotonic(), 0)]
         os.makedirs(self.download_dir, exist_ok=True)
         part_path = os.path.join(self.download_dir, "fonts.zip.part")
         extract_dir = os.path.join(self.download_dir, "extract")
-        if os.path.isdir(extract_dir):
-            shutil.rmtree(extract_dir, ignore_errors=True)
-        os.makedirs(extract_dir, exist_ok=True)
+        candidates = candidate_download_urls(url, use_mirrors=use_mirrors)
+        if not candidates:
+            raise FontPackError("没有可用的字体包下载地址", retryable=False, kind="config")
+        last_error: Exception | None = None
         try:
-            await self._stream_download(url, part_path, manifest.max_bytes)
-            digest = _sha256_file(part_path)
-            if digest != manifest.zip_sha256:
-                raise FontPackError("字体包 SHA256 校验失败", retryable=True, kind="hash")
-            self._extract_zip(part_path, extract_dir)
-            installed = self._collect_extracted_files(extract_dir, manifest)
-            self._verify_extracted(installed, manifest)
-            self._commit_files(installed, manifest)
-            self._write_local_manifest(manifest)
+            for index, candidate in enumerate(candidates):
+                self.downloaded = 0
+                self.total = 0
+                self._speed_samples = [(time.monotonic(), 0)]
+                if os.path.isdir(extract_dir):
+                    shutil.rmtree(extract_dir, ignore_errors=True)
+                os.makedirs(extract_dir, exist_ok=True)
+                if os.path.isfile(part_path):
+                    os.remove(part_path)
+                try:
+                    logger.info(
+                        "[Font] 开始下载字体包 (%s/%s) %s",
+                        index + 1,
+                        len(candidates),
+                        _safe_url(candidate),
+                    )
+                    await self._stream_download(candidate, part_path, manifest.max_bytes)
+                    digest = _sha256_file(part_path)
+                    if digest != manifest.zip_sha256:
+                        raise FontPackError("字体包 SHA256 校验失败", retryable=True, kind="hash")
+                    self._extract_zip(part_path, extract_dir)
+                    installed = self._collect_extracted_files(extract_dir, manifest)
+                    self._verify_extracted(installed, manifest)
+                    self._commit_files(installed, manifest)
+                    self._write_local_manifest(manifest)
+                    return
+                except asyncio.CancelledError:
+                    raise
+                except FontPackError as exc:
+                    last_error = exc
+                    logger.warning(
+                        "[Font] 字体包源失败 %s：%s",
+                        _safe_url(candidate),
+                        redact_sensitive(str(exc)),
+                    )
+                    if exc.kind in ("disk", "config", "manifest"):
+                        raise
+                    continue
+            if last_error:
+                raise last_error
+            raise FontPackError("没有可用的字体包下载地址", retryable=False, kind="config")
         finally:
             self._cleanup_download_dir()
 
     async def _stream_download(self, url: str, dest: str, max_bytes: int) -> None:
         import httpx
 
-        timeout = httpx.Timeout(self.timeout_sec)
+        timeout = httpx.Timeout(
+            connect=_CONNECT_TIMEOUT_SEC,
+            read=self.timeout_sec,
+            write=self.timeout_sec,
+            pool=_CONNECT_TIMEOUT_SEC,
+        )
         last_progress = 0.0
         last_bytes = 0
         try:

--- a/src/plugin/steam_status_monitor.py
+++ b/src/plugin/steam_status_monitor.py
@@ -173,7 +173,7 @@ class SteamStatusMonitorV3(
             proxy=self.proxy,
             enabled=bool(self.config.get("font_download_enabled", True)),
             pack_url=str(self.config.get("font_pack_url", "") or ""),
-            timeout_sec=int(self.config.get("font_download_timeout_sec", 120) or 120),
+            timeout_sec=int(self.config.get("font_download_timeout_sec", 600) or 600),
         )
         self._font_pack_task = self.font_pack.ensure_ready()
         self._load_group_steam_ids()  # 新增：优先从 steam_groups.json 加载

--- a/src/shared/fonts.py
+++ b/src/shared/fonts.py
@@ -10,7 +10,7 @@ from PIL import ImageFont
 from .logging import logger
 from .paths import FONTS_DIR, REQUIRED_FONT_FILES
 
-_warned_missing = False
+_logged_missing: set[str] = set()
 _path_cache: dict[str, str | None] = {}
 _data_fonts_dir = ""
 _bundled_dir = str(FONTS_DIR)
@@ -27,6 +27,7 @@ def configure_font_resolver(data_dir: str, bundled_dir: str | None = None) -> No
 
 def invalidate() -> None:
     _path_cache.clear()
+    _logged_missing.clear()
 
 
 def bundled_fonts_complete(bundled_dir: str | None = None) -> bool:
@@ -89,23 +90,27 @@ def resolve_font_path(name: str, *, bold: bool = False) -> str | None:
                         candidates.append(os.path.join(_data_fonts_dir, entry))
             except OSError:
                 pass
-    candidates.extend(_system_font_candidates(name, bold=bold))
 
     found = None
     for path in candidates:
         found = _existing_file(path)
         if found:
             break
+    if not found:
+        _error_missing_once(name)
+        for path in _system_font_candidates(name, bold=bold):
+            found = _existing_file(path)
+            if found:
+                break
     _path_cache[cache_key] = found
     return found
 
 
-def _warn_missing_once() -> None:
-    global _warned_missing
-    if _warned_missing:
+def _error_missing_once(name: str) -> None:
+    if name in _logged_missing:
         return
-    _warned_missing = True
-    logger.warning("CJK 字体未就绪，卡片可能出现方块字，正在后台下载")
+    _logged_missing.add(name)
+    logger.error("[Font] 找不到字体文件 %s，卡片可能出现方块字", name)
 
 
 def load_truetype(name: str, size: int, fallbacks: tuple[str, ...] | list[str] = ()):
@@ -128,5 +133,8 @@ def load_truetype(name: str, size: int, fallbacks: tuple[str, ...] | list[str] =
             return ImageFont.truetype(path, size)
         except Exception:
             continue
-    _warn_missing_once()
+    fallback_key = f"{name}|default"
+    if fallback_key not in _logged_missing:
+        _logged_missing.add(fallback_key)
+        logger.error("[Font] 字体 %s 加载失败，已回退默认字体，卡片可能出现方块字", name)
     return ImageFont.load_default()

--- a/tests/unit/test_font_pack.py
+++ b/tests/unit/test_font_pack.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 from src.infrastructure.fonts.pack_service import (
     FontPackError,
     FontPackService,
+    candidate_download_urls,
     load_manifest,
 )
 from src.shared.fonts import configure_font_resolver, invalidate, load_truetype, resolve_font_path
@@ -70,6 +71,30 @@ def _download_writer(zip_bytes: bytes):
     return _write
 
 
+GITHUB_ZIP = (
+    "https://github.com/Maoer233/astrbot_plugin_steam_status_monitor"
+    "/releases/download/fonts-bundle/astrbot_plugin_steam_status_monitor-fonts.zip"
+)
+
+
+class CandidateUrlTests(unittest.TestCase):
+    def test_github_release_uses_mirrors_then_official(self):
+        candidates = candidate_download_urls(GITHUB_ZIP)
+        self.assertEqual(4, len(candidates))
+        self.assertTrue(candidates[0].startswith("https://gh-proxy.com/"))
+        self.assertTrue(candidates[1].startswith("https://ghproxy.net/"))
+        self.assertTrue(candidates[2].startswith("https://github.akams.cn/"))
+        self.assertEqual(GITHUB_ZIP, candidates[-1])
+        self.assertTrue(all(GITHUB_ZIP in item for item in candidates[:-1]))
+
+    def test_non_github_url_is_not_wrapped(self):
+        url = "https://example.com/fonts.zip"
+        self.assertEqual([url], candidate_download_urls(url))
+
+    def test_mirrors_can_be_disabled(self):
+        self.assertEqual([GITHUB_ZIP], candidate_download_urls(GITHUB_ZIP, use_mirrors=False))
+
+
 class ManifestTests(unittest.TestCase):
     def test_rejects_missing_and_invalid_manifest(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -120,15 +145,30 @@ class FontResolverTests(unittest.TestCase):
     def test_load_truetype_does_not_raise_when_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
             configure_font_resolver(str(Path(tmp) / "data"), str(Path(tmp) / "bundled"))
-            font = load_truetype("definitely-missing.otf", 12)
-            self.assertIsNotNone(font)
+            with patch("src.shared.fonts.logger.error") as error:
+                font = load_truetype("definitely-missing.otf", 12)
+                self.assertIsNotNone(font)
+                messages = [" ".join(str(arg) for arg in call.args) for call in error.call_args_list]
+                self.assertTrue(any("definitely-missing.otf" in msg for msg in messages))
+                self.assertTrue(any("找不到字体文件" in msg for msg in messages))
+                first_count = error.call_count
+                load_truetype("definitely-missing.otf", 16)
+                self.assertEqual(first_count, error.call_count)
 
 
 class FontPackServiceTests(unittest.IsolatedAsyncioTestCase):
     async def asyncTearDown(self):
         invalidate()
 
-    def _service(self, tmp: str, manifest_path: str, bundled: str | None = None, enabled: bool = True) -> FontPackService:
+    def _service(
+        self,
+        tmp: str,
+        manifest_path: str,
+        bundled: str | None = None,
+        enabled: bool = True,
+        pack_url: str = "",
+        proxy: str | None = None,
+    ) -> FontPackService:
         data_dir = os.path.join(tmp, "data")
         os.makedirs(data_dir, exist_ok=True)
         bundled_dir = bundled or os.path.join(tmp, "bundled")
@@ -136,6 +176,8 @@ class FontPackServiceTests(unittest.IsolatedAsyncioTestCase):
         return FontPackService(
             data_dir,
             enabled=enabled,
+            pack_url=pack_url,
+            proxy=proxy,
             timeout_sec=5,
             bundled_dir=bundled_dir,
             manifest_path=manifest_path,
@@ -237,6 +279,68 @@ class FontPackServiceTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn(service.status, ("FAILED", "BACKOFF"))
             self.assertFalse(os.path.exists(service.download_dir))
             self.assertFalse(any((Path(service.fonts_dir) / name).exists() for name in REQUIRED))
+
+    async def test_falls_back_to_next_mirror(self):
+        payloads = _payloads()
+        zip_bytes = _make_zip(payloads)
+        files = [_file_spec(name, payloads[name]) for name in REQUIRED]
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            _write_manifest(manifest_path, zip_bytes, files, url=GITHUB_ZIP)
+            service = self._service(tmp, str(manifest_path))
+            seen: list[str] = []
+
+            async def _write(self, url, dest, max_bytes):
+                seen.append(url)
+                if len(seen) == 1:
+                    raise FontPackError("下载字体包网络错误: ConnectTimeout", retryable=True, kind="http")
+                return await _download_writer(zip_bytes)(self, url, dest, max_bytes)
+
+            with patch.object(FontPackService, "_stream_download", new=_write):
+                await service._install_once()
+            self.assertEqual("READY", service.status)
+            self.assertEqual(2, len(seen))
+            self.assertTrue(seen[0].startswith("https://gh-proxy.com/"))
+            self.assertTrue(seen[1].startswith("https://ghproxy.net/"))
+
+    async def test_custom_pack_url_skips_mirrors(self):
+        payloads = _payloads()
+        zip_bytes = _make_zip(payloads)
+        files = [_file_spec(name, payloads[name]) for name in REQUIRED]
+        custom = "https://cdn.example.com/fonts.zip"
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            _write_manifest(manifest_path, zip_bytes, files, url=GITHUB_ZIP)
+            service = self._service(tmp, str(manifest_path), pack_url=custom)
+            seen: list[str] = []
+
+            async def _write(self, url, dest, max_bytes):
+                seen.append(url)
+                return await _download_writer(zip_bytes)(self, url, dest, max_bytes)
+
+            with patch.object(FontPackService, "_stream_download", new=_write):
+                await service._install_once()
+            self.assertEqual("READY", service.status)
+            self.assertEqual([custom], seen)
+
+    async def test_proxy_skips_mirrors(self):
+        payloads = _payloads()
+        zip_bytes = _make_zip(payloads)
+        files = [_file_spec(name, payloads[name]) for name in REQUIRED]
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            _write_manifest(manifest_path, zip_bytes, files, url=GITHUB_ZIP)
+            service = self._service(tmp, str(manifest_path), proxy="http://127.0.0.1:7890")
+            seen: list[str] = []
+
+            async def _write(self, url, dest, max_bytes):
+                seen.append(url)
+                return await _download_writer(zip_bytes)(self, url, dest, max_bytes)
+
+            with patch.object(FontPackService, "_stream_download", new=_write):
+                await service._install_once()
+            self.assertEqual("READY", service.status)
+            self.assertEqual([GITHUB_ZIP], seen)
 
     async def test_cancel_cleans_download_dir(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
GitHub Release 下载先尝试 gh-proxy.com / ghproxy.net / github.akams.cn，失败再回退官方地址；连接超时约 15 秒以便换源，单个源读写超时默认 10 分钟。自定义 URL 或已开代理时不套镜像。bundled/数据目录找不到指定字体时按文件名打红色 error，同一进程每个文件名只打一次。
国内直连 GitHub 常超时导致整包重下；按文件名报错便于运维定位缺哪个字体，同时避免刷屏。