### PR TITLE
fix(price): 修正查价命令剥参并过滤无关 Steam 搜索结果

### DIFF
--- a/src/infrastructure/clients/itad.py
+++ b/src/infrastructure/clients/itad.py
@@ -77,7 +77,8 @@ class ITADClient:
                 result.append(ITADGame(game_id, title, item.get("url", ""), item.get("slug", ""), image))
         return result
 
-    async def _steam_search(self, query: str, language: str = "english", limit: int = 6):
+    async def _steam_storesearch(self, query: str, language: str = "english", limit: int = 6):
+        """只走 storesearch API，避免空结果时被 HTML 页的无关条目顶掉。"""
         try:
             async with httpx.AsyncClient(timeout=15, follow_redirects=True, **httpx_client_kwargs(self.proxy)) as client:
                 response = await client.get(
@@ -89,8 +90,15 @@ class ITADClient:
                 items = payload.get("items", []) if isinstance(payload, dict) else []
                 if isinstance(items, list) and items:
                     return items[:limit]
+                return []
+        except Exception as exc:
+            logger.warning("Steam storesearch 失败: %s", exc)
+            return []
 
-                # 商店客户端使用的搜索页索引有时比 storesearch API 更完整。
+    async def _steam_search_html(self, query: str, language: str = "english", limit: int = 6):
+        """商店搜索页兜底；国区成人内容经常被过滤，调用方需再做标题相关度校验。"""
+        try:
+            async with httpx.AsyncClient(timeout=15, follow_redirects=True, **httpx_client_kwargs(self.proxy)) as client:
                 page = await client.get(
                     "https://store.steampowered.com/search/results/",
                     params={"term": query, "l": language, "cc": "cn", "count": limit, "json": 1},
@@ -103,7 +111,6 @@ class ITADClient:
                 if results:
                     return results
 
-                # JSON 搜索接口可能返回空壳响应，再请求普通搜索页 HTML。
                 page = await client.get(
                     "https://store.steampowered.com/search/",
                     params={"term": query, "l": language, "cc": "cn"},
@@ -112,8 +119,14 @@ class ITADClient:
                 page.raise_for_status()
                 return self._parse_steam_search_html(page.text, limit)
         except Exception as exc:
-            logger.warning("Steam 搜索失败: %s", exc)
+            logger.warning("Steam 搜索页失败: %s", exc)
             return []
+
+    async def _steam_search(self, query: str, language: str = "english", limit: int = 6):
+        items = await self._steam_storesearch(query, language, limit)
+        if items:
+            return items
+        return await self._steam_search_html(query, language, limit)
 
     @staticmethod
     def _parse_steam_search_html(html: str, limit: int) -> list[dict[str, str]]:
@@ -175,53 +188,118 @@ class ITADClient:
             logger.warning("Steam 英文标题获取失败 appid=%s: %s", appid, exc)
             return ""
 
+    @staticmethod
+    def _query_tokens(query: str) -> list[str]:
+        tokens = re.findall(r"[0-9a-zA-Z]+|[\u4e00-\u9fff]+", str(query or "").casefold())
+        return [token for token in tokens if len(token) >= 2 or token.isdigit()]
+
+    @staticmethod
+    def _token_in_title(token: str, haystack: str) -> bool:
+        if re.fullmatch(r"[0-9a-z]+", token):
+            return re.search(rf"(?<![0-9a-z]){re.escape(token)}(?![0-9a-z])", haystack) is not None
+        return token in haystack
+
+    @classmethod
+    def _title_matches_query(cls, title: str, query: str) -> bool:
+        """标题需覆盖查询词中足够多的有效 token，避免 Steamy 糊到 steam。"""
+        tokens = cls._query_tokens(query)
+        if not tokens:
+            return bool(str(title or "").strip())
+        haystack = str(title or "").casefold()
+        if not haystack:
+            return False
+        if haystack == str(query or "").casefold().strip():
+            return True
+        matched = sum(1 for token in tokens if cls._token_in_title(token, haystack))
+        if len(tokens) == 1:
+            return matched == 1
+        return matched >= max(2, (len(tokens) + 1) // 2)
+
+    def _filter_steam_items(self, items, query: str, limit: int) -> list[dict]:
+        result = []
+        seen: set[str] = set()
+        for item in items or []:
+            if not isinstance(item, dict):
+                continue
+            appid = str(item.get("id") or "")
+            title = str(item.get("name") or "").strip()
+            if not appid or appid in seen or not title:
+                continue
+            if not self._title_matches_query(title, query):
+                continue
+            seen.add(appid)
+            result.append(item)
+            if len(result) >= limit:
+                break
+        return result
+
+    async def _lookup_steam_items(self, query: str, limit: int) -> list[dict]:
+        """优先 storesearch；HTML 页只在过滤后仍有相关标题时才采用。"""
+        for language in ("schinese", "english"):
+            items = self._filter_steam_items(
+                await self._steam_storesearch(query, language, limit), query, limit
+            )
+            if items:
+                return items
+        for language in ("schinese", "english"):
+            items = self._filter_steam_items(
+                await self._steam_search_html(query, language, limit), query, limit
+            )
+            if items:
+                return items
+        return []
+
     async def search_games(self, query: str, limit: int = 6) -> list[ITADGame]:
         """先通过 Steam 商店解析本地化名称，再用英文标题查询 ITAD。"""
-        steam_items = await self._steam_search(query, "schinese", limit)
-        if not steam_items:
-            steam_items = await self._steam_search(query, "english", limit)
+        steam_items = await self._lookup_steam_items(query, limit)
 
         # Steam 中文索引可能暂时没有结果；保留 ITAD 直搜作为兜底，避免中文查询完全失败。
         if not steam_items:
             fallback = await self._parse_search_payload(
                 await self._get("/games/search/v1", {"title": query, "results": limit}), limit
             )
-            for game in fallback:
-                candidates = await self._steam_search(game.title, "english", 3)
+            matched = [game for game in fallback if self._title_matches_query(game.title, query)]
+            for game in matched:
+                candidates = self._filter_steam_items(
+                    await self._steam_search(game.title, "english", 3), game.title, 3
+                )
                 if candidates:
                     game.appid = str(candidates[0].get("id") or "")
                     game.image = game.image or candidates[0].get("tiny_image", "")
-            return fallback
+            return matched[:limit]
 
         result: list[ITADGame] = []
-        seen_itad_ids: set[str] = set()
+        seen_keys: set[str] = set()
         for item in steam_items:
-            if not isinstance(item, dict):
-                continue
             appid = str(item.get("id") or "")
-            if not appid:
-                continue
             english_title = await self._steam_english_title(appid)
-            search_title = english_title or str(item.get("name") or "").strip()
+            local_title = str(item.get("name") or "").strip()
+            search_title = english_title or local_title
             if not search_title:
+                continue
+            if english_title and not (
+                self._title_matches_query(english_title, query)
+                or self._title_matches_query(local_title, query)
+            ):
                 continue
             itad_games = await self._parse_search_payload(
                 await self._get("/games/search/v1", {"title": search_title, "results": 3}), 3
             )
-            if not itad_games:
-                continue
             normalized_title = search_title.casefold()
             game = next(
                 (candidate for candidate in itad_games
                  if candidate.title.casefold().strip() == normalized_title),
-                itad_games[0],
+                None,
             )
-            if game.id in seen_itad_ids:
+            if game is None:
+                game = ITADGame(f"steam:{appid}", search_title)
+            dedupe_key = game.id or f"steam:{appid}"
+            if dedupe_key in seen_keys:
                 continue
             game.appid = appid
             game.title = english_title or game.title
             game.image = game.image or item.get("tiny_image", "")
-            seen_itad_ids.add(game.id)
+            seen_keys.add(dedupe_key)
             result.append(game)
             if len(result) >= limit:
                 break

--- a/src/plugin/steam_status_monitor.py
+++ b/src/plugin/steam_status_monitor.py
@@ -41,7 +41,7 @@ from ..infrastructure.clients.steam import SteamClientMixin
 from ..infrastructure.clients.itad import ITADClient
 from ..application.services.qq_menu_management import QQMenuManagementMixin
 from ..shared.paths import ABILITIES_PATH, CONFIG_PATH
-from ..shared.utils.price import summary_to_cny
+from ..shared.utils.price import extract_price_query, summary_to_cny
 from ..shared.utils.notify_session import is_sendable_group_session, is_valid_group_id
 
 # 状态文件最后写入距今超过该秒数（默认 60 分钟），视为插件停止期间遗留的陈旧状态。
@@ -637,13 +637,7 @@ class SteamStatusMonitorV3(
         if raw_msg is None:
             getter = getattr(event, "get_message_str", None)
             raw_msg = getter() if callable(getter) else ""
-        query = re.sub(
-            rf"^[/.。／]*\s*{re.escape(prefix)}\s*",
-            "",
-            str(raw_msg or ""),
-            count=1,
-            flags=re.IGNORECASE,
-        ).strip()
+        query = extract_price_query(str(raw_msg or ""), prefix)
         if not query:
             yield event.plain_result(f"用法：/steam {prefix} <游戏名或 Steam 链接>")
             return

--- a/src/shared/utils/price.py
+++ b/src/shared/utils/price.py
@@ -1,6 +1,7 @@
 # 价格折算工具：将 ITAD/Steam 返回的各地区货币统一折算为人民币(CNY)，用于同币种比较与显示。
 # 汇率表为 open.er-api.com 与 frankfurter.app 双源交叉核验值（差异 <0.4%，UTC 2026-08-30）；
 # 可直接修改 RATES 维护。
+import re
 
 RATES = {
     "CNY": 1.0,     # 人民币
@@ -16,6 +17,17 @@ RATES = {
     "BRL": 1.3063,  # 巴西雷亚尔
     "INR": 0.0705,  # 印度卢比
 }
+
+
+def extract_price_query(raw_msg: str, prefix: str) -> str:
+    """从完整消息中剥掉 /steam price（或 px）前缀，保留含空格的游戏名。"""
+    return re.sub(
+        rf"^[/.。／]*\s*(?:steam\s+)?{re.escape(prefix)}\s*",
+        "",
+        str(raw_msg or "").strip(),
+        count=1,
+        flags=re.IGNORECASE,
+    ).strip()
 
 
 def to_cny(price, currency, rates=None):

--- a/tests/unit/test_price_search.py
+++ b/tests/unit/test_price_search.py
@@ -1,0 +1,124 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from src.infrastructure.clients.itad import ITADClient
+from src.shared.utils.price import extract_price_query
+
+
+class PriceQueryExtractionTests(unittest.TestCase):
+    def test_strips_full_steam_price_command(self):
+        self.assertEqual(
+            "being a dik",
+            extract_price_query("/steam price being a dik", "price"),
+        )
+        self.assertEqual(
+            "being a dik",
+            extract_price_query("steam price being a dik", "price"),
+        )
+        self.assertEqual(
+            "being a dik",
+            extract_price_query("/steam px being a dik", "px"),
+        )
+
+    def test_keeps_already_stripped_query(self):
+        self.assertEqual(
+            "being a dik",
+            extract_price_query("being a dik", "price"),
+        )
+        self.assertEqual(
+            "being a dik",
+            extract_price_query("price being a dik", "price"),
+        )
+
+
+class TitleMatchTests(unittest.TestCase):
+    def test_being_a_dik_matches_series_not_steamy_dlc(self):
+        query = "being a dik"
+        self.assertTrue(ITADClient._title_matches_query("Being a DIK - Season 1", query))
+        self.assertTrue(ITADClient._title_matches_query("Being a DIK - Season 3", query))
+        self.assertFalse(
+            ITADClient._title_matches_query(
+                "The New Han Prince 3: Brother-in-Law's Steamy Indulgence",
+                query,
+            )
+        )
+        self.assertFalse(
+            ITADClient._title_matches_query(
+                "The New Han Prince 3: Brother-in-Law's Steamy Indulgence",
+                "steam price being a dik",
+            )
+        )
+
+    def test_single_token_still_matches(self):
+        self.assertTrue(ITADClient._title_matches_query("Being a DIK - Season 1", "dik"))
+        self.assertFalse(ITADClient._title_matches_query("Steam Machine", "dik"))
+        self.assertFalse(
+            ITADClient._title_matches_query(
+                "The New Han Prince 3: Brother-in-Law's Steamy Indulgence",
+                "steam",
+            )
+        )
+
+
+class SearchGamesTests(unittest.IsolatedAsyncioTestCase):
+    async def test_keeps_steam_hits_when_itad_is_empty(self):
+        client = ITADClient(api_key="test")
+        steam_items = [
+            {"id": "1126320", "name": "Being a DIK - Season 1", "tiny_image": "s1.jpg"},
+            {"id": "1807120", "name": "Being a DIK - Season 3", "tiny_image": "s3.jpg"},
+            {
+                "id": "5071090",
+                "name": "The New Han Prince 3: Brother-in-Law's Steamy Indulgence",
+                "tiny_image": "wrong.jpg",
+            },
+        ]
+        with (
+            patch.object(client, "_steam_storesearch", AsyncMock(side_effect=[steam_items, []])),
+            patch.object(client, "_steam_search_html", AsyncMock(return_value=[])),
+            patch.object(client, "_steam_english_title", AsyncMock(side_effect=lambda appid: {
+                "1126320": "Being a DIK - Season 1",
+                "1807120": "Being a DIK - Season 3",
+                "5071090": "The New Han Prince 3: Brother-in-Law's Steamy Indulgence",
+            }.get(appid, ""))),
+            patch.object(client, "_get", AsyncMock(return_value=[])),
+        ):
+            games = await client.search_games("being a dik")
+
+        self.assertEqual(["1126320", "1807120"], [game.appid for game in games])
+        self.assertTrue(all(game.id.startswith("steam:") for game in games))
+
+    async def test_html_unrelated_hits_are_ignored(self):
+        client = ITADClient(api_key="test")
+        html_items = [
+            {"id": "4287260", "name": "Rebirth: If Only I Had Grown Up Right"},
+            {"id": "2509780", "name": "汉武大帝传-国士无双礼包"},
+        ]
+        with (
+            patch.object(client, "_steam_storesearch", AsyncMock(return_value=[])),
+            patch.object(client, "_steam_search_html", AsyncMock(return_value=html_items)),
+            patch.object(client, "_get", AsyncMock(return_value=[
+                {"id": "itad-wrong", "title": "The New Han Prince 3: Brother-in-Law's Steamy Indulgence"},
+            ])),
+        ):
+            games = await client.search_games("being a dik")
+
+        self.assertEqual([], games)
+
+    async def test_itad_exact_title_is_kept_fuzzy_mismatch_is_not(self):
+        client = ITADClient(api_key="test")
+        steam_items = [
+            {"id": "1126320", "name": "Being a DIK - Season 1", "tiny_image": "s1.jpg"},
+        ]
+        with (
+            patch.object(client, "_steam_storesearch", AsyncMock(side_effect=[steam_items, []])),
+            patch.object(client, "_steam_search_html", AsyncMock(return_value=[])),
+            patch.object(client, "_steam_english_title", AsyncMock(return_value="Being a DIK - Season 1")),
+            patch.object(client, "_get", AsyncMock(return_value=[
+                {"id": "itad-s1", "title": "Being a DIK - Season 1"},
+                {"id": "itad-wrong", "title": "The New Han Prince 3: Brother-in-Law's Steamy Indulgence"},
+            ])),
+        ):
+            games = await client.search_games("being a dik")
+
+        self.assertEqual(["1126320"], [game.appid for game in games])
+        self.assertEqual(["itad-s1"], [game.id for game in games])


### PR DESCRIPTION
从完整消息中剥掉 /steam price 或 px 前缀，避免把 steam 当成游戏名；storesearch 与 HTML 搜索分开，并按标题 token 相关度过滤，ITAD 无精确匹配时仍保留 Steam 命中。
原先 HTML 兜底会把无关成人内容顶到候选首位，且命令前缀残留会导致 Steamy 误匹配；按标题覆盖查询词后再查价，避免直接给出错误 appid。