### PR TITLE
fix: 修复排行榜遗漏推送用户与空群轮询残留问题 (#45 #46)

### DIFF
--- a/src/application/services/monitor_admin.py
+++ b/src/application/services/monitor_admin.py
@@ -94,6 +94,15 @@ class MonitorAdminService:
             self.groups[owner] = [sid for sid in owner_ids if sid != steam_id]
             if not self.groups[owner]:
                 del self.groups[owner]
+                # 群已空，停止该群的监控轮询
+                running_groups = getattr(self._plugin, 'running_groups', set())
+                running_groups.discard(owner)
+                monitor_enabled = getattr(self._plugin, 'group_monitor_enabled', {})
+                monitor_enabled.pop(owner, None)
+                notify_sessions = getattr(self._plugin, 'notify_sessions', {})
+                notify_sessions.pop(owner, None)
+                self._plugin._save_notify_session()
+                self._plugin._save_group_switches()
         push_groups.pop(steam_id, None)
         self._plugin._save_group_steam_ids()
         self._plugin._save_push_groups()

--- a/src/application/services/polling_tracking.py
+++ b/src/application/services/polling_tracking.py
@@ -59,7 +59,7 @@ class PollingTrackingMixin:
                 next_minute = (int(now) // 60 + 1) * 60
                 await asyncio.sleep(max(0, next_minute - now))
                 # 0秒：跨群收集所有到点的SteamID，合并为一次批量查询（N群=1次API调用+自动去重）
-                group_ids = list(self.group_steam_ids.keys())
+                group_ids = list(self.running_groups)  # 只轮询已启动的群，避免未启动群残留轮询
                 group_sids = {}  # {group_id: [sid, ...]}
                 all_sids_set = set()
                 now2 = time.time()

--- a/src/plugin/steam_status_monitor.py
+++ b/src/plugin/steam_status_monitor.py
@@ -1696,7 +1696,15 @@ class SteamStatusMonitorV3(
                 date_keys.append(d.strftime("%Y-%m-%d"))
             # 确定要统计的 SteamID 集合
             if group_id:
-                target_sids = set(self.group_steam_ids.get(group_id, []))
+                # 主监控ID
+                direct_steam_ids = self.group_steam_ids.get(group_id, [])
+                # 子群推送ID（从 push_groups 中查找推送到该群的 SteamID）
+                push_steam_ids = [
+                    sid
+                    for sid, push_targets in (getattr(self, 'push_groups', {}) or {}).items()
+                    if group_id in {str(target) for target in push_targets}
+                ]
+                target_sids = set(direct_steam_ids) | set(push_steam_ids)
             else:
                 target_sids = set()
                 for gids in self.group_steam_ids.values():


### PR DESCRIPTION
## 概述
本 PR 修复了两个相关的 bug：
1. **排行榜统计遗漏联动推送用户** (#45)
2. **删除 SteamID 后空群轮询残留** (#46)